### PR TITLE
Remove stale docs

### DIFF
--- a/Sources/SwiftUICharts/BarChart/Models/Datapoints/MultiBarChartDataPoint.swift
+++ b/Sources/SwiftUICharts/BarChart/Models/Datapoints/MultiBarChartDataPoint.swift
@@ -13,7 +13,6 @@ import SwiftUI
  # Example
  ```
  MultiBarChartDataPoint(value: 10,
-                        xAxisLabel: "1.1",
                         description: "One One",
                         group: GroupingData(title: "One", colour: .blue))
  ```


### PR DESCRIPTION
The example shows one setting the x-axis in the constructor, but the definition of the constructor itself does not allow this. This PR fixes that.