### PR TITLE
Add data stream of touch data point

### DIFF
--- a/Sources/SwiftUICharts/BarChart/Models/ChartData/BarChartData.swift
+++ b/Sources/SwiftUICharts/BarChart/Models/ChartData/BarChartData.swift
@@ -6,11 +6,12 @@
 //
 
 import SwiftUI
+import Combine
 
 /**
  Data for drawing and styling a standard Bar Chart.
  */
-public final class BarChartData: CTBarChartDataProtocol {
+public final class BarChartData: CTBarChartDataProtocol, Publishable {
     // MARK: Properties
     public let id: UUID = UUID()
     
@@ -25,6 +26,10 @@ public final class BarChartData: CTBarChartDataProtocol {
     @Published public final var infoView: InfoViewData<BarChartDataPoint> = InfoViewData()
     
     @Published public final var extraLineData: ExtraLineData!
+    
+    // Publishable
+    public var subscription = SubscriptionSet().subscription
+    public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
     public final var noDataText: Text
     public final let chartType: (chartType: ChartType, dataSetType: DataSetType)
@@ -128,6 +133,7 @@ public final class BarChartData: CTBarChartDataProtocol {
         if index >= 0 && index < dataSets.dataPoints.count {
             dataSets.dataPoints[index].legendTag = dataSets.legendTitle
             self.infoView.touchOverlayInfo = [dataSets.dataPoints[index]]
+            touchedDataPointPublisher.send(dataSets.dataPoints[index])
         }
     }
     
@@ -142,7 +148,7 @@ public final class BarChartData: CTBarChartDataProtocol {
         return nil
     }
     
-    public typealias Set = BarDataSet
+    public typealias SetType = BarDataSet
     public typealias DataPoint = BarChartDataPoint
     public typealias CTStyle = BarChartStyle
 }

--- a/Sources/SwiftUICharts/BarChart/Models/ChartData/GroupedBarChartData.swift
+++ b/Sources/SwiftUICharts/BarChart/Models/ChartData/GroupedBarChartData.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 
 /**
  Data model for drawing and styling a Grouped Bar Chart.
@@ -13,7 +14,7 @@ import SwiftUI
  The grouping data informs the model as to how the datapoints are linked.
  ```
  */
-public final class GroupedBarChartData: CTMultiBarChartDataProtocol {
+public final class GroupedBarChartData: CTMultiBarChartDataProtocol, Publishable {
     
     // MARK: Properties
     public let id: UUID = UUID()
@@ -30,6 +31,10 @@ public final class GroupedBarChartData: CTMultiBarChartDataProtocol {
     @Published public final var groups: [GroupingData]
     
     @Published public final var extraLineData: ExtraLineData!
+    
+    // Publishable
+    public var subscription = SubscriptionSet().subscription
+    public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
     public final var noDataText: Text
     public final var chartType: (chartType: ChartType, dataSetType: DataSetType)
@@ -156,6 +161,7 @@ public final class GroupedBarChartData: CTMultiBarChartDataProtocol {
             if subIndex >= 0 && subIndex < dataSets.dataSets[index].dataPoints.count {
                 dataSets.dataSets[index].dataPoints[subIndex].legendTag = dataSets.dataSets[index].setTitle
                 self.infoView.touchOverlayInfo = [dataSets.dataSets[index].dataPoints[subIndex]]
+                touchedDataPointPublisher.send(dataSets.dataSets[index].dataPoints[subIndex])
             }
         }
     }
@@ -189,7 +195,7 @@ public final class GroupedBarChartData: CTMultiBarChartDataProtocol {
         return nil
     }
     
-    public typealias Set = GroupedBarDataSets
+    public typealias SetType = GroupedBarDataSets
     public typealias DataPoint = GroupedBarDataPoint
     public typealias CTStyle = BarChartStyle
 }

--- a/Sources/SwiftUICharts/BarChart/Models/ChartData/HorizontalBarChartData.swift
+++ b/Sources/SwiftUICharts/BarChart/Models/ChartData/HorizontalBarChartData.swift
@@ -6,11 +6,12 @@
 //
 
 import SwiftUI
+import Combine
 
 /**
  Data for drawing and styling a standard Bar Chart.
  */
-public final class HorizontalBarChartData: CTHorizontalBarChartDataProtocol {
+public final class HorizontalBarChartData: CTHorizontalBarChartDataProtocol, Publishable {
     // MARK: Properties
     public let id: UUID = UUID()
     
@@ -25,6 +26,10 @@ public final class HorizontalBarChartData: CTHorizontalBarChartDataProtocol {
     @Published public final var infoView: InfoViewData<BarChartDataPoint> = InfoViewData()
     
     @Published public final var extraLineData: ExtraLineData!
+    
+    // Publishable
+    public var subscription = SubscriptionSet().subscription
+    public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
     public final var noDataText: Text
     public final let chartType: (chartType: ChartType, dataSetType: DataSetType)
@@ -167,6 +172,7 @@ public final class HorizontalBarChartData: CTHorizontalBarChartDataProtocol {
         if index >= 0 && index < dataSets.dataPoints.count {
             dataSets.dataPoints[index].legendTag = dataSets.legendTitle
             self.infoView.touchOverlayInfo = [dataSets.dataPoints[index]]
+            touchedDataPointPublisher.send(dataSets.dataPoints[index])
         }
     }
     
@@ -181,7 +187,7 @@ public final class HorizontalBarChartData: CTHorizontalBarChartDataProtocol {
         return nil
     }
     
-    public typealias Set = BarDataSet
+    public typealias SetType = BarDataSet
     public typealias DataPoint = BarChartDataPoint
     public typealias CTStyle = BarChartStyle
 }

--- a/Sources/SwiftUICharts/BarChart/Models/ChartData/RangedBarChartData.swift
+++ b/Sources/SwiftUICharts/BarChart/Models/ChartData/RangedBarChartData.swift
@@ -6,11 +6,12 @@
 //
 
 import SwiftUI
+import Combine
 
 /**
  Data for drawing and styling a ranged Bar Chart.
  */
-public final class RangedBarChartData: CTRangedBarChartDataProtocol {
+public final class RangedBarChartData: CTRangedBarChartDataProtocol, Publishable {
     // MARK: Properties
     public let id: UUID = UUID()
     
@@ -25,6 +26,10 @@ public final class RangedBarChartData: CTRangedBarChartDataProtocol {
     @Published public final var infoView: InfoViewData<RangedBarDataPoint> = InfoViewData()
     
     @Published public final var extraLineData: ExtraLineData!
+    
+    // Publishable
+    public var subscription = SubscriptionSet().subscription
+    public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
     public final var noDataText: Text
     public final let chartType: (chartType: ChartType, dataSetType: DataSetType)
@@ -138,6 +143,7 @@ public final class RangedBarChartData: CTRangedBarChartDataProtocol {
         if index >= 0 && index < dataSets.dataPoints.count {
             dataSets.dataPoints[index].legendTag = dataSets.legendTitle
             self.infoView.touchOverlayInfo = [dataSets.dataPoints[index]]
+            touchedDataPointPublisher.send(dataSets.dataPoints[index])
         }
     }
     
@@ -152,7 +158,7 @@ public final class RangedBarChartData: CTRangedBarChartDataProtocol {
         return nil
     }
     
-    public typealias Set = RangedBarDataSet
+    public typealias SetType = RangedBarDataSet
     public typealias DataPoint = RangedBarDataPoint
     public typealias CTStyle = BarChartStyle
 }

--- a/Sources/SwiftUICharts/BarChart/Models/ChartData/StackedBarChartData.swift
+++ b/Sources/SwiftUICharts/BarChart/Models/ChartData/StackedBarChartData.swift
@@ -6,13 +6,14 @@
 //
 
 import SwiftUI
+import Combine
 
 /**
  Data model for drawing and styling a Stacked Bar Chart.
  
  The grouping data informs the model as to how the datapoints are linked.
  */
-public final class StackedBarChartData: CTMultiBarChartDataProtocol {
+public final class StackedBarChartData: CTMultiBarChartDataProtocol, Publishable {
     
     // MARK: Properties
     public let id: UUID = UUID()
@@ -29,6 +30,10 @@ public final class StackedBarChartData: CTMultiBarChartDataProtocol {
     @Published public final var groups: [GroupingData]
     
     @Published public final var extraLineData: ExtraLineData!
+    
+    // Publishable
+    public var subscription = SubscriptionSet().subscription
+    public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
     public final var noDataText: Text
     public final var chartType: (chartType: ChartType, dataSetType: DataSetType)
@@ -139,6 +144,7 @@ public final class StackedBarChartData: CTMultiBarChartDataProtocol {
                 if index >= 0 && index < dataSets.dataSets[superIndex].dataPoints.count {
                     dataSets.dataSets[superIndex].dataPoints[index].legendTag = dataSets.dataSets[superIndex].setTitle
                     self.infoView.touchOverlayInfo = [dataSets.dataSets[superIndex].dataPoints[index]]
+                    touchedDataPointPublisher.send(dataSets.dataSets[superIndex].dataPoints[index])
                 }
             }
         }
@@ -198,7 +204,7 @@ public final class StackedBarChartData: CTMultiBarChartDataProtocol {
         return (yIndex, endPointOfElements)
     }
     
-    public typealias Set = StackedBarDataSets
+    public typealias SetType = StackedBarDataSets
     public typealias DataPoint = StackedBarDataPoint
     public typealias CTStyle = BarChartStyle
 }

--- a/Sources/SwiftUICharts/BarChart/Models/Protocols/BarChartProtocolsExtensions.swift
+++ b/Sources/SwiftUICharts/BarChart/Models/Protocols/BarChartProtocolsExtensions.swift
@@ -46,10 +46,10 @@ extension CTBarChartDataProtocol where Self.CTStyle.Mark == BarMarkerType {
 //
 //
 // MARK: Standard / Ranged
-extension CTBarChartDataProtocol where Self.Set.ID == UUID,
-                                       Self.Set.DataPoint.ID == UUID,
-                                       Self.Set: CTStandardBarChartDataSet,
-                                       Self.Set.DataPoint: CTBarColourProtocol {
+extension CTBarChartDataProtocol where Self.SetType.ID == UUID,
+                                       Self.SetType.DataPoint.ID == UUID,
+                                       Self.SetType: CTStandardBarChartDataSet,
+                                       Self.SetType.DataPoint: CTBarColourProtocol {
     internal func setupLegends() {
         switch self.barStyle.colourFrom {
         case .barStyle:

--- a/Sources/SwiftUICharts/BarChart/Views/SubViews/Bars.swift
+++ b/Sources/SwiftUICharts/BarChart/Views/SubViews/Bars.swift
@@ -336,13 +336,13 @@ internal struct GradientStopsPartBar: View {
 internal struct RangedBarChartColourCell<CD:RangedBarChartData>: View {
     
     private let chartData: CD
-    private let dataPoint: CD.Set.DataPoint
+    private let dataPoint: CD.SetType.DataPoint
     private let colour: Color
     private let barSize: CGRect
     
     internal init(
         chartData: CD,
-        dataPoint: CD.Set.DataPoint,
+        dataPoint: CD.SetType.DataPoint,
         colour: Color,
         barSize: CGRect
     ) {
@@ -379,7 +379,7 @@ internal struct RangedBarChartColourCell<CD:RangedBarChartData>: View {
 internal struct RangedBarChartColoursCell<CD:RangedBarChartData>: View {
     
     private let chartData: CD
-    private let dataPoint: CD.Set.DataPoint
+    private let dataPoint: CD.SetType.DataPoint
     private let colours: [Color]
     private let startPoint: UnitPoint
     private let endPoint: UnitPoint
@@ -387,7 +387,7 @@ internal struct RangedBarChartColoursCell<CD:RangedBarChartData>: View {
     
     internal init(
         chartData: CD,
-        dataPoint: CD.Set.DataPoint,
+        dataPoint: CD.SetType.DataPoint,
         colours: [Color],
         startPoint: UnitPoint,
         endPoint: UnitPoint,
@@ -430,7 +430,7 @@ internal struct RangedBarChartColoursCell<CD:RangedBarChartData>: View {
 internal struct RangedBarChartStopsCell<CD:RangedBarChartData>: View {
     
     private let chartData: CD
-    private let dataPoint: CD.Set.DataPoint
+    private let dataPoint: CD.SetType.DataPoint
     private let stops: [Gradient.Stop]
     private let startPoint: UnitPoint
     private let endPoint: UnitPoint
@@ -438,7 +438,7 @@ internal struct RangedBarChartStopsCell<CD:RangedBarChartData>: View {
     
     internal init(
         chartData: CD,
-        dataPoint: CD.Set.DataPoint,
+        dataPoint: CD.SetType.DataPoint,
         stops: [Gradient.Stop],
         startPoint: UnitPoint,
         endPoint: UnitPoint,

--- a/Sources/SwiftUICharts/LineChart/Extras/LineChartEnums.swift
+++ b/Sources/SwiftUICharts/LineChart/Extras/LineChartEnums.swift
@@ -62,7 +62,7 @@ public enum PointShape {
  case point // Attached to the data points.
  ```
  */
-public enum MarkerAttachemnt {
+public enum MarkerAttachment {
     /// Attached to the line.
     case line(dot: Dot)
     /// Attached to the data points.
@@ -74,12 +74,12 @@ public enum MarkerAttachemnt {
  ```
  case none // No overlay markers.
  case indicator(style: DotStyle) // Dot that follows the path.
- case vertical(attachment: MarkerAttachemnt) // Vertical line from top to bottom.
- case full(attachment: MarkerAttachemnt) // Full width and height of view intersecting at a specified point.
- case bottomLeading(attachment: MarkerAttachemnt) // From bottom and leading edges meeting at a specified point.
- case bottomTrailing(attachment: MarkerAttachemnt) // From bottom and trailing edges meeting at a specified point.
- case topLeading(attachment: MarkerAttachemnt) // From top and leading edges meeting at a specified point.
- case topTrailing(attachment: MarkerAttachemnt) // From top and trailing edges meeting at a specified point.
+ case vertical(attachment: MarkerAttachment) // Vertical line from top to bottom.
+ case full(attachment: MarkerAttachment) // Full width and height of view intersecting at a specified point.
+ case bottomLeading(attachment: MarkerAttachment) // From bottom and leading edges meeting at a specified point.
+ case bottomTrailing(attachment: MarkerAttachment) // From bottom and trailing edges meeting at a specified point.
+ case topLeading(attachment: MarkerAttachment) // From top and leading edges meeting at a specified point.
+ case topTrailing(attachment: MarkerAttachment) // From top and trailing edges meeting at a specified point.
  ```
  */
 public enum LineMarkerType: MarkerType {
@@ -88,17 +88,17 @@ public enum LineMarkerType: MarkerType {
     /// Dot that follows the path.
     case indicator(style: DotStyle)
     /// Vertical line from top to bottom.
-    case vertical(attachment: MarkerAttachemnt, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
+    case vertical(attachment: MarkerAttachment, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
     /// Full width and height of view intersecting at a specified point.
-    case full(attachment: MarkerAttachemnt, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
+    case full(attachment: MarkerAttachment, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
     /// From bottom and leading edges meeting at a specified point.
-    case bottomLeading(attachment: MarkerAttachemnt, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
+    case bottomLeading(attachment: MarkerAttachment, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
     /// From bottom and trailing edges meeting at a specified point.
-    case bottomTrailing(attachment: MarkerAttachemnt, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
+    case bottomTrailing(attachment: MarkerAttachment, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
     /// From top and leading edges meeting at a specified point.
-    case topLeading(attachment: MarkerAttachemnt, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
+    case topLeading(attachment: MarkerAttachment, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
     /// From top and trailing edges meeting at a specified point.
-    case topTrailing(attachment: MarkerAttachemnt, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
+    case topTrailing(attachment: MarkerAttachment, colour: Color = Color.primary, style: StrokeStyle = StrokeStyle())
 }
 
 /**

--- a/Sources/SwiftUICharts/LineChart/Models/ChartData/LineChartData.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/ChartData/LineChartData.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 
 /**
  Data for drawing and styling a single line, line chart.
@@ -30,6 +31,9 @@ public final class LineChartData: CTLineChartDataProtocol {
     public final var chartType: (chartType: ChartType, dataSetType: DataSetType)
     
     @Published public final var extraLineData: ExtraLineData!
+    
+    public var subscription = SubscriptionSet().subscription
+    public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
     internal final var isFilled: Bool = false
     
@@ -75,7 +79,6 @@ public final class LineChartData: CTLineChartDataProtocol {
                             if let label = self.dataSets.dataPoints[i].xAxisLabel {
                                 if label != "" {
                                     TempText(chartData: self, label: label, rotation: angle)
-                                        
                                         .frame(width: min(self.getXSection(dataSet: self.dataSets, chartSize: self.viewData.chartSize), self.viewData.xAxislabelWidths.min() ?? 0),
                                                height: self.viewData.xAxisLabelHeights.max() ?? 0)
                                         .offset(x: CGFloat(i) * (geo.frame(in: .local).width / CGFloat(self.dataSets.dataPoints.count - 1)),
@@ -181,6 +184,7 @@ extension LineChartData {
                     self.infoView.touchOverlayInfo = [dataSets.dataPoints[index]]
                 }
             }
+            touchedDataPointPublisher.send(dataSets.dataPoints[index])
         }
     }
 }

--- a/Sources/SwiftUICharts/LineChart/Models/ChartData/LineChartData.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/ChartData/LineChartData.swift
@@ -13,7 +13,7 @@ import Combine
  
  This model contains the data and styling information for a single line, line chart.
  */
-public final class LineChartData: CTLineChartDataProtocol {
+public final class LineChartData: CTLineChartDataProtocol, Publishable {
     
     // MARK: Properties
     public final let id: UUID = UUID()
@@ -32,6 +32,7 @@ public final class LineChartData: CTLineChartDataProtocol {
     
     @Published public final var extraLineData: ExtraLineData!
     
+    // Publishable
     public var subscription = SubscriptionSet().subscription
     public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
@@ -136,7 +137,7 @@ public final class LineChartData: CTLineChartDataProtocol {
                            chartSize: chartSize)
     }
     
-    public typealias Set = LineDataSet
+    public typealias SetType = LineDataSet
     public typealias DataPoint = LineChartDataPoint
 }
 

--- a/Sources/SwiftUICharts/LineChart/Models/ChartData/MultiLineChartData.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/ChartData/MultiLineChartData.swift
@@ -6,13 +6,14 @@
 //
 
 import SwiftUI
+import Combine
 
 /**
  Data for drawing and styling a multi line, line chart.
  
  This model contains all the data and styling information for a single line, line chart.
  */
-public final class MultiLineChartData: CTLineChartDataProtocol {
+public final class MultiLineChartData: CTLineChartDataProtocol, Publishable {
     
     // MARK: Properties
     public let id: UUID = UUID()
@@ -30,6 +31,10 @@ public final class MultiLineChartData: CTLineChartDataProtocol {
     public final var chartType: (chartType: ChartType, dataSetType: DataSetType)
     
     @Published public final var extraLineData: ExtraLineData!
+    
+    // Publishable
+    public var subscription = SubscriptionSet().subscription
+    public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
     // MARK: Initializers
     /// Initialises a Multi Line Chart.
@@ -152,7 +157,7 @@ public final class MultiLineChartData: CTLineChartDataProtocol {
         }
     }
     
-    public typealias Set = MultiLineDataSet
+    public typealias SetType = MultiLineDataSet
     public typealias DataPoint = LineChartDataPoint
     public typealias CTStyle = LineChartStyle
 }
@@ -182,11 +187,11 @@ extension MultiLineChartData {
     }
     
     public func getDataPoint(touchLocation: CGPoint, chartSize: CGRect) {
-        
         self.infoView.touchOverlayInfo = dataSets.dataSets.indices.compactMap { setIndex in
             let xSection: CGFloat = chartSize.width / CGFloat(dataSets.dataSets[setIndex].dataPoints.count - 1)
             let index = Int((touchLocation.x + (xSection / 2)) / xSection)
             if index >= 0 && index < dataSets.dataSets[setIndex].dataPoints.count {
+                touchedDataPointPublisher.send(dataSets.dataSets[setIndex].dataPoints[index])
                 if !dataSets.dataSets[setIndex].style.ignoreZero {
                     dataSets.dataSets[setIndex].dataPoints[index].legendTag = dataSets.dataSets[setIndex].legendTitle
                     return dataSets.dataSets[setIndex].dataPoints[index]

--- a/Sources/SwiftUICharts/LineChart/Models/ChartData/RangedLineChartData.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/ChartData/RangedLineChartData.swift
@@ -6,13 +6,14 @@
 //
 
 import SwiftUI
+import Combine
 
 /**
  Data for drawing and styling ranged line chart.
  
  This model contains the data and styling information for a ranged line chart.
  */
-public final class RangedLineChartData: CTLineChartDataProtocol {
+public final class RangedLineChartData: CTLineChartDataProtocol, Publishable {
     
     // MARK: Properties
     public let id: UUID  = UUID()
@@ -30,6 +31,10 @@ public final class RangedLineChartData: CTLineChartDataProtocol {
     public final var chartType: (chartType: ChartType, dataSetType: DataSetType)
     
     @Published public final var extraLineData: ExtraLineData!
+    
+    // Publishable
+    public var subscription = SubscriptionSet().subscription
+    public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
     // MARK: Initializer
     /// Initialises a ranged line chart.
@@ -179,9 +184,10 @@ public final class RangedLineChartData: CTLineChartDataProtocol {
                     self.infoView.touchOverlayInfo = [dataSets.dataPoints[index]]
                 }
             }
+            touchedDataPointPublisher.send(dataSets.dataPoints[index])
         }
     }
     
-    public typealias Set = RangedLineDataSet
+    public typealias SetType = RangedLineDataSet
     public typealias DataPoint = RangedLineChartDataPoint
 }

--- a/Sources/SwiftUICharts/LineChart/Models/Protocols/LineChartProtocolsExtensions.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/Protocols/LineChartProtocolsExtensions.swift
@@ -504,14 +504,14 @@ internal struct IndicatorSwitch: View {
 }
 
 // MARK: - Legends
-extension CTLineChartDataProtocol where Self.Set.ID == UUID,
-                                        Self.Set: CTLineChartDataSet {
+extension CTLineChartDataProtocol where Self.SetType.ID == UUID,
+                                        Self.SetType: CTLineChartDataSet {
     internal func setupLegends() {
         lineLegendSetup(dataSet: dataSets)
     }
 }
 
-extension CTLineChartDataProtocol where Self.Set == MultiLineDataSet {
+extension CTLineChartDataProtocol where Self.SetType == MultiLineDataSet {
     internal func setupLegends() {
         dataSets.dataSets.forEach { lineLegendSetup(dataSet: $0) }
     }
@@ -554,9 +554,9 @@ extension CTLineChartDataProtocol {
     }
 }
 
-extension CTLineChartDataProtocol where Self.Set.ID == UUID,
-                                        Self.Set: CTRangedLineChartDataSet,
-                                        Self.Set.Styling: CTRangedLineStyle {
+extension CTLineChartDataProtocol where Self.SetType.ID == UUID,
+                                        Self.SetType: CTRangedLineChartDataSet,
+                                        Self.SetType.Styling: CTRangedLineStyle {
     internal func setupRangeLegends() {
         if dataSets.style.fillColour.colourType == .colour,
            let colour = dataSets.style.fillColour.colour
@@ -594,7 +594,7 @@ extension CTLineChartDataProtocol where Self.Set.ID == UUID,
 }
 
 // MARK: - Accessibility
-extension CTLineChartDataProtocol where Set: CTLineChartDataSet {
+extension CTLineChartDataProtocol where SetType: CTLineChartDataSet {
     public func getAccessibility() -> some View {
         ForEach(dataSets.dataPoints.indices, id: \.self) { point in
             

--- a/Sources/SwiftUICharts/PieChart/Models/ChartData/DoughnutChartData.swift
+++ b/Sources/SwiftUICharts/PieChart/Models/ChartData/DoughnutChartData.swift
@@ -6,13 +6,14 @@
 //
 
 import SwiftUI
+import Combine
 
 /**
  Data for drawing and styling a doughnut chart.
  
  This model contains the data and styling information for a doughnut chart.
  */
-public final class DoughnutChartData: CTDoughnutChartDataProtocol {
+public final class DoughnutChartData: CTDoughnutChartDataProtocol, Publishable {
     
     // MARK: Properties
     public var id: UUID = UUID()
@@ -21,6 +22,10 @@ public final class DoughnutChartData: CTDoughnutChartDataProtocol {
     @Published public final var chartStyle: DoughnutChartStyle
     @Published public final var legends: [LegendData]
     @Published public final var infoView: InfoViewData<PieChartDataPoint>
+    
+    // Publishable
+    public var subscription = SubscriptionSet().subscription
+    public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
     public final var noDataText: Text
     public final var chartType: (chartType: ChartType, dataSetType: DataSetType)
@@ -53,7 +58,7 @@ public final class DoughnutChartData: CTDoughnutChartDataProtocol {
     
     public final func getTouchInteraction(touchLocation: CGPoint, chartSize: CGRect) -> some View { EmptyView() }
     
-    public typealias Set = PieDataSet
+    public typealias SetType = PieDataSet
     public typealias DataPoint = PieChartDataPoint
     public typealias CTStyle = DoughnutChartStyle
 }
@@ -70,6 +75,7 @@ extension DoughnutChartData {
         guard let wrappedIndex = index else { return }
         self.dataSets.dataPoints[wrappedIndex].legendTag = dataSets.legendTitle
         self.infoView.touchOverlayInfo = [self.dataSets.dataPoints[wrappedIndex]]
+        touchedDataPointPublisher.send(self.dataSets.dataPoints[wrappedIndex])
     }
     public func getPointLocation(dataSet: PieDataSet, touchLocation: CGPoint, chartSize: CGRect) -> CGPoint? {
         return nil

--- a/Sources/SwiftUICharts/PieChart/Models/ChartData/PieChartData.swift
+++ b/Sources/SwiftUICharts/PieChart/Models/ChartData/PieChartData.swift
@@ -6,13 +6,14 @@
 //
 
 import SwiftUI
+import Combine
 
 /**
  Data for drawing and styling a pie chart.
  
  This model contains the data and styling information for a pie chart.
  */
-public final class PieChartData: CTPieChartDataProtocol {
+public final class PieChartData: CTPieChartDataProtocol, Publishable {
     
     // MARK: Properties
     public var id: UUID = UUID()
@@ -21,6 +22,10 @@ public final class PieChartData: CTPieChartDataProtocol {
     @Published public final var chartStyle: PieChartStyle
     @Published public final var legends: [LegendData]
     @Published public final var infoView: InfoViewData<PieChartDataPoint>
+    
+    // Publishable
+    public var subscription = SubscriptionSet().subscription
+    public let touchedDataPointPublisher = PassthroughSubject<DataPoint,Never>()
     
     public final var noDataText: Text
     public final var chartType: (chartType: ChartType, dataSetType: DataSetType)
@@ -53,7 +58,7 @@ public final class PieChartData: CTPieChartDataProtocol {
     
     public final func getTouchInteraction(touchLocation: CGPoint, chartSize: CGRect) -> some View { EmptyView() }
     
-    public typealias Set = PieDataSet
+    public typealias SetType = PieDataSet
     public typealias DataPoint = PieChartDataPoint
     public typealias CTStyle = PieChartStyle
 }
@@ -71,6 +76,7 @@ extension PieChartData {
         guard let wrappedIndex = index else { return }
         self.dataSets.dataPoints[wrappedIndex].legendTag = dataSets.legendTitle
         self.infoView.touchOverlayInfo = [self.dataSets.dataPoints[wrappedIndex]]
+        touchedDataPointPublisher.send(self.dataSets.dataPoints[wrappedIndex])
     }
     
     public func getPointLocation(dataSet: PieDataSet, touchLocation: CGPoint, chartSize: CGRect) -> CGPoint? {

--- a/Sources/SwiftUICharts/PieChart/Models/Protocols/PieChartProtocolsExtentions.swift
+++ b/Sources/SwiftUICharts/PieChart/Models/Protocols/PieChartProtocolsExtentions.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 // MARK: - Extentions
 
-extension CTPieDoughnutChartDataProtocol where Set == PieDataSet, DataPoint == PieChartDataPoint {
+extension CTPieDoughnutChartDataProtocol where SetType == PieDataSet, DataPoint == PieChartDataPoint {
     
     /**
      Sets up the data points in a way that can be sent to renderer for drawing.
@@ -56,9 +56,9 @@ extension CTPieDoughnutChartDataProtocol where Set == PieDataSet, DataPoint == P
     }
 }
 
-extension CTPieDoughnutChartDataProtocol where Self.Set.DataPoint.ID == UUID,
-                                               Self.Set: CTSingleDataSetProtocol,
-                                               Self.Set.DataPoint: CTPieDataPoint {
+extension CTPieDoughnutChartDataProtocol where Self.SetType.DataPoint.ID == UUID,
+                                               Self.SetType: CTSingleDataSetProtocol,
+                                               Self.SetType.DataPoint: CTPieDataPoint {
     internal func setupLegends() {
         dataSets.dataPoints.forEach { dataPoint in
             guard let legend = dataPoint.description else { return }

--- a/Sources/SwiftUICharts/Shared/Models/Protocols/PublishableProtocol.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/PublishableProtocol.swift
@@ -1,0 +1,27 @@
+//
+//  PublishableProtocol.swift
+//  
+//
+//  Created by Will Dale on 05/06/2021.
+//
+
+import Foundation
+import Combine
+
+/**
+ Protocol to enable publishing data streams over the Combine framework
+ */
+public protocol Publishable {
+    
+    associatedtype DataPoint: CTDataPointBaseProtocol
+    
+    
+    var subscription: Set<AnyCancellable> { get set }
+    
+    /**
+     Streams the data points from touch overlay.
+     
+     Uses Combine
+     */
+    var touchedDataPointPublisher: PassthroughSubject<DataPoint, Never> { get }
+}

--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocols.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocols.swift
@@ -8,6 +8,21 @@
 import SwiftUI
 
 
+import Combine
+public protocol Publishable {
+    
+    associatedtype DataPoint: CTDataPointBaseProtocol
+    
+    var subscription: Set<AnyCancellable> { get set }
+    
+    /**
+     Streams the data points from touch overlay.
+     
+     Uses Combine
+     */
+    var touchedDataPointPublisher: PassthroughSubject<DataPoint, Never> { get }
+}
+
 // MARK: Chart Data
 /**
  Main protocol for passing data around library.
@@ -17,7 +32,7 @@ import SwiftUI
 public protocol CTChartData: ObservableObject, Identifiable {
     
     /// A type representing a  data set. -- `CTDataSetProtocol`
-    associatedtype Set: CTDataSetProtocol
+    associatedtype SetType: CTDataSetProtocol
     
     /// A type representing a  data set. -- `CTDataSetProtocol`
     associatedtype SetPoint: CTDataSetProtocol
@@ -36,7 +51,7 @@ public protocol CTChartData: ObservableObject, Identifiable {
     /**
      Data model containing datapoints and styling information.
      */
-    var dataSets: Set { get set }
+    var dataSets: SetType { get set }
     
     /**
      Data model containing the charts Title, Subtitle and the Title for Legend.

--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocols.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocols.swift
@@ -7,22 +7,6 @@
 
 import SwiftUI
 
-
-import Combine
-public protocol Publishable {
-    
-    associatedtype DataPoint: CTDataPointBaseProtocol
-    
-    var subscription: Set<AnyCancellable> { get set }
-    
-    /**
-     Streams the data points from touch overlay.
-     
-     Uses Combine
-     */
-    var touchedDataPointPublisher: PassthroughSubject<DataPoint, Never> { get }
-}
-
 // MARK: Chart Data
 /**
  Main protocol for passing data around library.

--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
@@ -9,28 +9,28 @@ import SwiftUI
 
 // MARK: - Is Greater Than
 extension CTChartData where Self: CTLineChartDataProtocol,
-                            Set: CTSingleDataSetProtocol {
+                            SetType: CTSingleDataSetProtocol {
     public func isGreaterThanTwo() -> Bool {
         return dataSets.dataPoints.count >= 2
     }
 }
 
 extension CTChartData where Self: CTBarChartDataProtocol,
-                            Set: CTSingleDataSetProtocol {
+                            SetType: CTSingleDataSetProtocol {
     public func isGreaterThanTwo() -> Bool {
         return dataSets.dataPoints.count >= 1
     }
 }
 
 extension CTChartData where Self: CTPieDoughnutChartDataProtocol,
-                            Set: CTSingleDataSetProtocol {
+                            SetType: CTSingleDataSetProtocol {
     public func isGreaterThanTwo() -> Bool {
         return dataSets.dataPoints.count >= 1
     }
 }
 
 extension CTChartData where Self: CTLineChartDataProtocol,
-                            Set: CTMultiDataSetProtocol {
+                            SetType: CTMultiDataSetProtocol {
     public func isGreaterThanTwo() -> Bool {
         var returnValue: [Bool] = []
         dataSets.dataSets.forEach { dataSet in
@@ -41,7 +41,7 @@ extension CTChartData where Self: CTLineChartDataProtocol,
 }
 
 extension CTChartData where Self: CTBarChartDataProtocol,
-                            Set: CTMultiDataSetProtocol {
+                            SetType: CTMultiDataSetProtocol {
     public func isGreaterThanTwo() -> Bool {
         var returnValue: [Bool] = []
         dataSets.dataSets.forEach { dataSet in

--- a/Sources/SwiftUICharts/Shared/Models/SubscriptionSet.swift
+++ b/Sources/SwiftUICharts/Shared/Models/SubscriptionSet.swift
@@ -1,0 +1,13 @@
+//
+//  SubscriptionSet.swift
+//  
+//
+//  Created by Will Dale on 04/06/2021.
+//
+
+import Foundation
+import Combine
+
+internal class SubscriptionSet {
+    internal var subscription = Set<AnyCancellable>()
+}

--- a/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/LineAndBarProtocolsExtentions.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/LineAndBarProtocolsExtentions.swift
@@ -268,14 +268,14 @@ extension CTLineBarChartDataProtocol {
     }
 }
 extension CTLineBarChartDataProtocol where Self: CTLineChartDataProtocol,
-                                           Self.Set: CTLineChartDataSet {
+                                           Self.SetType: CTLineChartDataSet {
     public func getColour() -> ColourStyle {
         dataSets.style.lineColour
     }
 }
 extension CTLineBarChartDataProtocol where Self: CTLineChartDataProtocol,
-                                           Self.Set: CTMultiLineChartDataSet,
-                                           Self.Set.DataSet: CTLineChartDataSet {
+                                           Self.SetType: CTMultiLineChartDataSet,
+                                           Self.SetType.DataSet: CTLineChartDataSet {
     public func getColour() -> ColourStyle {
         dataSets.dataSets.first?.style.lineColour ?? ColourStyle()
     }


### PR DESCRIPTION
# New
- Uses the Combine framework to stream the data point from a touch interaction via a PassthroughSubject. See #85 

# Fixes
- Rename the associatedtype `Set` to `SetType` to avoid a naming conflict. -- My bad!
- A typo: MarkerAttachemnt to MarkerAttachment. See #81 .