### PR TITLE
Stop line chart with the IgnoreMe flag set to true from drawing.

### DIFF
--- a/Sources/SwiftUICharts/LineChart/Extras/PathExtensions.swift
+++ b/Sources/SwiftUICharts/LineChart/Extras/PathExtensions.swift
@@ -8,6 +8,10 @@
 import SwiftUI
 
 // MARK: - Standard
+//
+//
+//
+// MARK: Line
 extension Path {
     
     /// Draws straight lines between data points.
@@ -82,6 +86,7 @@ extension Path {
         return path
     }
     
+    // MARK: Box
     /// Draws straight lines between data points.
     static func straightLineBox<DP:CTRangedLineDataPoint>(
         rect: CGRect,
@@ -170,9 +175,13 @@ extension Path {
 }
 
 // MARK: - Ignore Zero
+//
+//
+//
+// MARK: Line
 extension Path {
     /// Draws straight lines between data points ignoring any values of zero.
-    static func straightLineIgnoreZero<DP:CTStandardDataPointProtocol>(
+    static func straightLineIgnoreZero<DP:CTStandardDataPointProtocol & IgnoreMe>(
         rect: CGRect,
         dataPoints: [DP],
         minValue: Double,
@@ -198,7 +207,7 @@ extension Path {
                 let nextPoint = CGPoint(x: CGFloat(index) * x,
                                         y: (CGFloat(dataPoints[index].value - minValue) * -y) + rect.height)
                 
-                if dataPoints[index].value != 0 {
+                if dataPoints[index].value != 0 && !dataPoints[index].ignoreMe {
                     path.addLine(to: nextPoint)
                 }
             }
@@ -212,7 +221,7 @@ extension Path {
     }
     
     /// Draws cubic Bézier curved lines between data points.
-    static func curvedLineIgnoreZero<DP:CTStandardDataPointProtocol>(
+    static func curvedLineIgnoreZero<DP:CTStandardDataPointProtocol & IgnoreMe>(
         rect: CGRect,
         dataPoints: [DP],
         minValue: Double,
@@ -242,7 +251,7 @@ extension Path {
             let nextPoint = CGPoint(x: CGFloat(index) * x,
                                     y: (CGFloat(dataPoints[index].value - minValue) * -y) + rect.height)
             
-            if dataPoints[index].value != 0 {
+            if dataPoints[index].value != 0 && !dataPoints[index].ignoreMe {
                 path.addCurve(to: nextPoint,
                               control1: CGPoint(x: previousPoint.x + (nextPoint.x - previousPoint.x) / 2,
                                                 y: previousPoint.y),
@@ -263,8 +272,9 @@ extension Path {
         return path
     }
     
+    // MARK: Box
     /// Draws straight lines between data points.
-    static func straightLineBoxIgnoreZero<DP:CTRangedLineDataPoint>(
+    static func straightLineBoxIgnoreZero<DP:CTRangedLineDataPoint & IgnoreMe>(
         rect: CGRect,
         dataPoints: [DP],
         minValue: Double,
@@ -305,7 +315,7 @@ extension Path {
     }
     
     /// Draws straight lines between data points.
-    static func curvedLineBoxIgnoreZero<DP:CTRangedLineDataPoint>(
+    static func curvedLineBoxIgnoreZero<DP:CTRangedLineDataPoint & IgnoreMe>(
         rect: CGRect,
         dataPoints: [DP],
         minValue: Double,

--- a/Sources/SwiftUICharts/LineChart/Models/ChartData/LineChartData.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/ChartData/LineChartData.swift
@@ -181,7 +181,7 @@ extension LineChartData {
                     self.infoView.touchOverlayInfo = [dataSets.dataPoints[index]]
                 } else {
                     dataSets.dataPoints[index].legendTag = dataSets.legendTitle
-                    dataSets.dataPoints[index].value = -Double.greatestFiniteMagnitude
+                    dataSets.dataPoints[index].ignoreMe = true
                     self.infoView.touchOverlayInfo = [dataSets.dataPoints[index]]
                 }
             }

--- a/Sources/SwiftUICharts/LineChart/Models/ChartData/MultiLineChartData.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/ChartData/MultiLineChartData.swift
@@ -201,7 +201,7 @@ extension MultiLineChartData {
                         return dataSets.dataSets[setIndex].dataPoints[index]
                     } else {
                         dataSets.dataSets[setIndex].dataPoints[index].legendTag = dataSets.dataSets[setIndex].legendTitle
-                        dataSets.dataSets[setIndex].dataPoints[index].value = -Double.greatestFiniteMagnitude
+                        dataSets.dataSets[setIndex].dataPoints[index].ignoreMe = true
                         return dataSets.dataSets[setIndex].dataPoints[index]
                     }
                 }

--- a/Sources/SwiftUICharts/LineChart/Models/ChartData/RangedLineChartData.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/ChartData/RangedLineChartData.swift
@@ -180,7 +180,7 @@ public final class RangedLineChartData: CTLineChartDataProtocol, Publishable {
                     self.infoView.touchOverlayInfo = [dataSets.dataPoints[index]]
                 } else {
                     dataSets.dataPoints[index].legendTag = dataSets.legendTitle
-                    dataSets.dataPoints[index].value = -Double.greatestFiniteMagnitude
+                    dataSets.dataPoints[index].ignoreMe = true
                     self.infoView.touchOverlayInfo = [dataSets.dataPoints[index]]
                 }
             }

--- a/Sources/SwiftUICharts/LineChart/Models/DataPoints/LineChartDataPoint.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/DataPoints/LineChartDataPoint.swift
@@ -10,13 +10,15 @@ import SwiftUI
 /**
  Data for a single data point.
  */
-public struct LineChartDataPoint: CTStandardLineDataPoint {
+public struct LineChartDataPoint: CTStandardLineDataPoint, IgnoreMe {
     
     public let id: UUID = UUID()
     public var value: Double
     public var xAxisLabel: String?
     public var description: String?
     public var date: Date?
+    
+    public var ignoreMe: Bool = false
     
     public var legendTag: String = ""
     

--- a/Sources/SwiftUICharts/LineChart/Models/DataPoints/RangedLineChartDataPoint.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/DataPoints/RangedLineChartDataPoint.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /**
  Data for a single ranged data point.
  */
-public struct RangedLineChartDataPoint: CTRangedLineDataPoint {
+public struct RangedLineChartDataPoint: CTRangedLineDataPoint, IgnoreMe {
     
     public let id: UUID = UUID()
     public var value: Double
@@ -19,6 +19,8 @@ public struct RangedLineChartDataPoint: CTRangedLineDataPoint {
     public var xAxisLabel: String?
     public var description: String?
     public var date: Date?
+    
+    public var ignoreMe: Bool = false
     
     public var legendTag: String = ""
     

--- a/Sources/SwiftUICharts/LineChart/Models/Protocols/LineChartProtocols.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/Protocols/LineChartProtocols.swift
@@ -139,3 +139,9 @@ public protocol CTStandardLineDataPoint: CTLineDataPointProtocol, CTStandardData
  */
 public protocol CTRangedLineDataPoint: CTLineDataPointProtocol, CTStandardDataPointProtocol, CTRangeDataPointProtocol, CTisRanged {}
 
+
+
+
+public protocol IgnoreMe {
+    var ignoreMe: Bool { get set }
+}

--- a/Sources/SwiftUICharts/LineChart/Models/Protocols/LineChartProtocolsExtensions.swift
+++ b/Sources/SwiftUICharts/LineChart/Models/Protocols/LineChartProtocolsExtensions.swift
@@ -7,12 +7,40 @@
 
 import SwiftUI
 
+// MARK: - Box Location
+extension CTLineBarChartDataProtocol {
+    public func setBoxLocationation(touchLocation: CGFloat, boxFrame: CGRect, chartSize: CGRect) -> CGFloat {        
+        var returnPoint: CGFloat = .zero
+        if touchLocation < chartSize.minX + (boxFrame.width / 2) {
+            returnPoint = chartSize.minX + (boxFrame.width / 2)
+        } else if touchLocation > chartSize.maxX - (boxFrame.width / 2) {
+            returnPoint = chartSize.maxX - (boxFrame.width / 2)
+        } else {
+            returnPoint = touchLocation
+        }
+        return returnPoint + (self.viewData.yAxisLabelWidth.max() ?? 0) + self.viewData.yAxisTitleWidth + (self.viewData.hasYAxisLabels ? 4 : 0) // +4 For Padding
+    }
+}
+extension CTLineBarChartDataProtocol where Self: isHorizontal {
+    public func setBoxLocationation(touchLocation: CGFloat, boxFrame: CGRect, chartSize: CGRect) -> CGFloat {
+        var returnPoint: CGFloat = .zero
+        if touchLocation < chartSize.minY + (boxFrame.height / 2) {
+            returnPoint = chartSize.minY + (boxFrame.height / 2)
+        } else if touchLocation > chartSize.maxY - (boxFrame.height / 2) {
+            returnPoint = chartSize.maxY - (boxFrame.height / 2)
+        } else {
+            returnPoint = touchLocation
+        }
+        return returnPoint
+    }
+}
+
 // MARK: - Position Indicator
 extension CTLineChartDataProtocol {
     /**
      Gets the position on a line relative to where the location of the touch or pointer interaction.
      */
-    public static func getIndicatorLocation<DP:CTStandardDataPointProtocol>(
+    internal static func getIndicatorLocation<DP:CTStandardDataPointProtocol & IgnoreMe>(
         rect: CGRect,
         dataPoints: [DP],
         touchLocation: CGPoint,
@@ -31,6 +59,7 @@ extension CTLineChartDataProtocol {
         return Self.locationOnPath(Self.getPercentageOfPath(path: path, touchLocation: touchLocation), path)
     }
 }
+
 extension CTLineChartDataProtocol {
     /**
      Returns the relevent path based on the line type.
@@ -46,7 +75,7 @@ extension CTLineChartDataProtocol {
         - ignoreZero: Whether or not Zeros should be drawn.
      - Returns: The relevent path based on the line type
      */
-    static func getPath<DP:CTStandardDataPointProtocol>(
+    static func getPath<DP:CTStandardDataPointProtocol & IgnoreMe>(
         lineType: LineType,
         rect: CGRect,
         dataPoints: [DP],
@@ -274,7 +303,7 @@ extension CTLineChartDataProtocol {
 extension CTLineChartDataProtocol where Self.CTStyle.Mark == LineMarkerType {
     
     internal func markerSubView<DS: CTLineChartDataSet,
-                                DP: CTStandardDataPointProtocol>(
+                                DP: CTStandardDataPointProtocol & IgnoreMe>(
         dataSet: DS,
         dataPoints: [DP],
         lineType: LineType,
@@ -298,12 +327,11 @@ extension CTLineChartDataProtocol where Self.CTStyle.Mark == LineMarkerType {
                                                         minValue: self.minValue,
                                                         range: self.range,
                                                         ignoreZero: dataSet.style.ignoreZero))
-                
             case .vertical(attachment: let attach, let colour, let style):
-                
+
                 switch attach {
                 case .line(dot: let indicator):
-                    
+
                     let position = Self.getIndicatorLocation(rect: chartSize,
                                                              dataPoints: dataPoints,
                                                              touchLocation: touchLocation,
@@ -311,12 +339,12 @@ extension CTLineChartDataProtocol where Self.CTStyle.Mark == LineMarkerType {
                                                              minValue: self.minValue,
                                                              range: self.range,
                                                              ignoreZero: dataSet.style.ignoreZero)
-                    
+
                     Vertical(position: position)
                         .stroke(colour, style: style)
-                    
+
                     IndicatorSwitch(indicator: indicator, location: position)
-                    
+
                 case .point:
                     if let position = self.getPointLocation(dataSet: dataSet as! Self.SetPoint,
                                                             touchLocation: touchLocation,
@@ -325,12 +353,12 @@ extension CTLineChartDataProtocol where Self.CTStyle.Mark == LineMarkerType {
                             .stroke(colour, style: style)
                     }
                 }
-                
+
             case .full(attachment: let attach, let colour, let style):
-                
+
                 switch attach {
                 case .line(dot: let indicator):
-                    
+
                     let position = Self.getIndicatorLocation(rect: chartSize,
                                                              dataPoints: dataPoints,
                                                              touchLocation: touchLocation,
@@ -338,29 +366,29 @@ extension CTLineChartDataProtocol where Self.CTStyle.Mark == LineMarkerType {
                                                              minValue: self.minValue,
                                                              range: self.range,
                                                              ignoreZero: dataSet.style.ignoreZero)
-                    
+
                     MarkerFull(position: position)
                         .stroke(colour, style: style)
-                    
+
                     IndicatorSwitch(indicator: indicator, location: position)
-                    
-                    
+
+
                 case .point:
-                    
+
                     if let position = self.getPointLocation(dataSet: dataSet as! Self.SetPoint,
                                                             touchLocation: touchLocation,
                                                             chartSize: chartSize) {
-                        
+
                         MarkerFull(position: position)
                             .stroke(colour, style: style)
                     }
                 }
-                
+
             case .bottomLeading(attachment: let attach, let colour, let style):
-                
+
                 switch attach {
                 case .line(dot: let indicator):
-                    
+
                     let position = Self.getIndicatorLocation(rect: chartSize,
                                                              dataPoints: dataPoints,
                                                              touchLocation: touchLocation,
@@ -368,28 +396,28 @@ extension CTLineChartDataProtocol where Self.CTStyle.Mark == LineMarkerType {
                                                              minValue: self.minValue,
                                                              range: self.range,
                                                              ignoreZero: dataSet.style.ignoreZero)
-                    
+
                     MarkerBottomLeading(position: position)
                         .stroke(Color.primary, lineWidth: 2)
-                    
+
                     IndicatorSwitch(indicator: indicator, location: position)
-                    
+
                 case .point:
-                    
+
                     if let position = self.getPointLocation(dataSet: dataSet as! Self.SetPoint,
                                                             touchLocation: touchLocation,
                                                             chartSize: chartSize) {
-                        
+
                         MarkerBottomLeading(position: position)
                             .stroke(colour, style: style)
                     }
                 }
-                
+
             case .bottomTrailing(attachment: let attach, let colour, let style):
-                
+
                 switch attach {
                 case .line(dot: let indicator):
-                    
+
                     let position = Self.getIndicatorLocation(rect: chartSize,
                                                              dataPoints: dataPoints,
                                                              touchLocation: touchLocation,
@@ -397,28 +425,28 @@ extension CTLineChartDataProtocol where Self.CTStyle.Mark == LineMarkerType {
                                                              minValue: self.minValue,
                                                              range: self.range,
                                                              ignoreZero: dataSet.style.ignoreZero)
-                    
+
                     MarkerBottomTrailing(position: position)
                         .stroke(colour, style: style)
-                    
+
                     IndicatorSwitch(indicator: indicator, location: position)
-                    
+
                 case .point:
-                    
+
                     if let position = self.getPointLocation(dataSet: dataSet as! Self.SetPoint,
                                                             touchLocation: touchLocation,
                                                             chartSize: chartSize) {
-                        
+
                         MarkerBottomTrailing(position: position)
                             .stroke(colour, style: style)
                     }
                 }
-                
+
             case .topLeading(attachment: let attach, let colour, let style):
-                
+
                 switch attach {
                 case .line(dot: let indicator):
-                    
+
                     let position = Self.getIndicatorLocation(rect: chartSize,
                                                              dataPoints: dataPoints,
                                                              touchLocation: touchLocation,
@@ -426,28 +454,28 @@ extension CTLineChartDataProtocol where Self.CTStyle.Mark == LineMarkerType {
                                                              minValue: self.minValue,
                                                              range: self.range,
                                                              ignoreZero: dataSet.style.ignoreZero)
-                    
+
                     MarkerTopLeading(position: position)
                         .stroke(colour, style: style)
-                    
+
                     IndicatorSwitch(indicator: indicator, location: position)
-                    
+
                 case .point:
-                    
+
                     if let position = self.getPointLocation(dataSet: dataSet as! Self.SetPoint,
                                                             touchLocation: touchLocation,
                                                             chartSize: chartSize) {
-                        
+
                         MarkerTopLeading(position: position)
                             .stroke(colour, style: style)
                     }
                 }
-                
+
             case .topTrailing(attachment: let attach, let colour, let style):
-                
+
                 switch attach {
                 case .line(dot: let indicator):
-                    
+
                     let position = Self.getIndicatorLocation(rect: chartSize,
                                                              dataPoints: dataPoints,
                                                              touchLocation: touchLocation,
@@ -455,18 +483,18 @@ extension CTLineChartDataProtocol where Self.CTStyle.Mark == LineMarkerType {
                                                              minValue: self.minValue,
                                                              range: self.range,
                                                              ignoreZero: dataSet.style.ignoreZero)
-                    
+
                     MarkerTopTrailing(position: position)
                         .stroke(colour, style: style)
-                    
+
                     IndicatorSwitch(indicator: indicator, location: position)
-                    
+
                 case .point:
-                    
+
                     if let position = self.getPointLocation(dataSet: dataSet as! Self.SetPoint,
                                                             touchLocation: touchLocation,
                                                             chartSize: chartSize) {
-                        
+
                         MarkerTopTrailing(position: position)
                             .stroke(colour, style: style)
                     }

--- a/Sources/SwiftUICharts/LineChart/Shapes/LineShape.swift
+++ b/Sources/SwiftUICharts/LineChart/Shapes/LineShape.swift
@@ -10,7 +10,7 @@ import SwiftUI
 /**
  Main line shape
  */
-internal struct LineShape<DP>: Shape where DP: CTStandardDataPointProtocol {
+internal struct LineShape<DP>: Shape where DP: CTStandardDataPointProtocol & IgnoreMe {
     
     private let dataPoints: [DP]
     private let lineType: LineType
@@ -59,7 +59,7 @@ internal struct LineShape<DP>: Shape where DP: CTStandardDataPointProtocol {
  Background fill based on the upper and lower values
  for a Ranged Line Chart.
  */
-internal struct RangedLineFillShape<DP>: Shape where DP: CTRangedLineDataPoint {
+internal struct RangedLineFillShape<DP>: Shape where DP: CTRangedLineDataPoint & IgnoreMe {
     
     private let dataPoints: [DP]
     private let lineType: LineType

--- a/Sources/SwiftUICharts/LineChart/Views/SubViews/LineChartSubViews.swift
+++ b/Sources/SwiftUICharts/LineChart/Views/SubViews/LineChartSubViews.swift
@@ -15,7 +15,7 @@ import SwiftUI
  */
 internal struct LineChartColourSubView<CD, DS>: View where CD: CTLineChartDataProtocol,
                                                            DS: CTLineChartDataSet,
-                                                           DS.DataPoint: CTStandardDataPointProtocol {
+                                                           DS.DataPoint: CTStandardDataPointProtocol & IgnoreMe {
     private let chartData: CD
     private let dataSet: DS
     private let minValue: Double
@@ -76,7 +76,7 @@ internal struct LineChartColourSubView<CD, DS>: View where CD: CTLineChartDataPr
  */
 internal struct LineChartColoursSubView<CD, DS>: View where CD: CTLineChartDataProtocol,
                                                             DS: CTLineChartDataSet,
-                                                            DS.DataPoint: CTStandardDataPointProtocol {
+                                                            DS.DataPoint: CTStandardDataPointProtocol & IgnoreMe {
     private let chartData: CD
     private let dataSet: DS
     private let minValue: Double
@@ -149,7 +149,7 @@ internal struct LineChartColoursSubView<CD, DS>: View where CD: CTLineChartDataP
  */
 internal struct LineChartStopsSubView<CD, DS>: View where CD: CTLineChartDataProtocol,
                                                           DS: CTLineChartDataSet,
-                                                          DS.DataPoint: CTStandardDataPointProtocol {
+                                                          DS.DataPoint: CTStandardDataPointProtocol & IgnoreMe {
     private let chartData: CD
     private let dataSet: DS
     private let minValue: Double

--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
@@ -135,33 +135,6 @@ extension CTChartData {
     }
 }
 
-extension CTLineBarChartDataProtocol {
-    public func setBoxLocationation(touchLocation: CGFloat, boxFrame: CGRect, chartSize: CGRect) -> CGFloat {
-        var returnPoint: CGFloat = .zero
-        if touchLocation < chartSize.minX + (boxFrame.width / 2) {
-            returnPoint = chartSize.minX + (boxFrame.width / 2)
-        } else if touchLocation > chartSize.maxX - (boxFrame.width / 2) {
-            returnPoint = chartSize.maxX - (boxFrame.width / 2)
-        } else {
-            returnPoint = touchLocation
-        }
-        return returnPoint + (self.viewData.yAxisLabelWidth.max() ?? 0) + self.viewData.yAxisTitleWidth + (self.viewData.hasYAxisLabels ? 4 : 0) // +4 For Padding
-    }
-}
-extension CTLineBarChartDataProtocol where Self: isHorizontal {
-    public func setBoxLocationation(touchLocation: CGFloat, boxFrame: CGRect, chartSize: CGRect) -> CGFloat {
-        var returnPoint: CGFloat = .zero
-        if touchLocation < chartSize.minY + (boxFrame.height / 2) {
-            returnPoint = chartSize.minY + (boxFrame.height / 2)
-        } else if touchLocation > chartSize.maxY - (boxFrame.height / 2) {
-            returnPoint = chartSize.maxY - (boxFrame.height / 2)
-        } else {
-            returnPoint = touchLocation
-        }
-        return returnPoint
-    }
-}
-
 // MARK: - Data Set
 extension CTSingleDataSetProtocol where Self.DataPoint: CTStandardDataPointProtocol & CTnotRanged {
     public func maxValue() -> Double {
@@ -303,10 +276,10 @@ extension CTDataPointBaseProtocol {
     }
 }
 
-extension CTStandardDataPointProtocol {
+extension CTStandardDataPointProtocol where Self: IgnoreMe {
     /// Data point's value as a string
     public func valueAsString(specifier: String) -> String {
-        if self.value != -Double.greatestFiniteMagnitude {
+        if !self.ignoreMe {
             return String(format: specifier, self.value)
         } else {
             return String("")

--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
@@ -276,7 +276,13 @@ extension CTDataPointBaseProtocol {
     }
 }
 
-extension CTStandardDataPointProtocol where Self: IgnoreMe {
+extension CTStandardDataPointProtocol where Self: CTBarDataPointBaseProtocol {
+    /// Data point's value as a string
+    public func valueAsString(specifier: String) -> String {
+            return String(format: specifier, self.value)
+    }
+}
+extension CTStandardDataPointProtocol where Self: CTLineDataPointProtocol & IgnoreMe {
     /// Data point's value as a string
     public func valueAsString(specifier: String) -> String {
         if !self.ignoreMe {
@@ -284,6 +290,12 @@ extension CTStandardDataPointProtocol where Self: IgnoreMe {
         } else {
             return String("")
         }
+    }
+}
+extension CTStandardDataPointProtocol where Self: CTPieDataPoint {
+    /// Data point's value as a string
+    public func valueAsString(specifier: String) -> String {
+            return String(format: specifier, self.value)
     }
 }
 


### PR DESCRIPTION
# Fixes
- When the a data set has `ignoreZero` set to true, the touch overlay no longer draws extra data points. See #90 