### PR TITLE
Add protections for divide by zero.

### DIFF
--- a/Sources/SwiftUICharts/BarChart/Views/StackedBarChart.swift
+++ b/Sources/SwiftUICharts/BarChart/Views/StackedBarChart.swift
@@ -60,7 +60,7 @@ public struct StackedBarChart<ChartData>: View where ChartData: StackedBarChartD
             HStack(alignment: .bottom, spacing: 0) {
                 ForEach(chartData.dataSets.dataSets) { dataSet in
                     StackElementSubView(dataSet: dataSet, specifier: chartData.infoView.touchSpecifier)
-                        .scaleEffect(y: startAnimation ? CGFloat(dataSet.maxValue() / chartData.maxValue) : 0, anchor: .bottom)
+                        .scaleEffect(y: startAnimation ? divideByZeroProtection(CGFloat.self, dataSet.maxValue(), chartData.maxValue) : 0, anchor: .bottom)
                         .scaleEffect(x: chartData.barStyle.barWidth, anchor: .center)
                         .background(Color(.gray).opacity(0.000000001))
                         .animateOnAppear(using: chartData.chartStyle.globalAnimation) {

--- a/Sources/SwiftUICharts/BarChart/Views/SubViews/Bars.swift
+++ b/Sources/SwiftUICharts/BarChart/Views/SubViews/Bars.swift
@@ -42,7 +42,7 @@ internal struct ColourBar<CD: CTBarChartDataProtocol & GetDataProtocol,
                                  bl: chartData.barStyle.cornerRadius.bottom,
                                  br: chartData.barStyle.cornerRadius.bottom)
             .fill(colour)
-            .scaleEffect(y: startAnimation ? CGFloat(dataPoint.value / chartData.maxValue) : 0, anchor: .bottom)
+            .scaleEffect(y: startAnimation ? divideByZeroProtection(CGFloat.self, dataPoint.value, chartData.maxValue) : 0, anchor: .bottom)
             .scaleEffect(x: chartData.barStyle.barWidth, anchor: .center)
             .background(Color(.gray).opacity(0.000000001))
             .animateOnAppear(using: chartData.chartStyle.globalAnimation) {
@@ -54,7 +54,6 @@ internal struct ColourBar<CD: CTBarChartDataProtocol & GetDataProtocol,
             .accessibilityValue(dataPoint.getCellAccessibilityValue(specifier: chartData.infoView.touchSpecifier))
     }
 }
-
 
 // MARK: Gradient
 /**
@@ -95,7 +94,7 @@ internal struct GradientColoursBar<CD: CTBarChartDataProtocol & GetDataProtocol,
             .fill(LinearGradient(gradient: Gradient(colors: colours),
                                  startPoint: startPoint,
                                  endPoint: endPoint))
-            .scaleEffect(y: startAnimation ? CGFloat(dataPoint.value / chartData.maxValue) : 0, anchor: .bottom)
+            .scaleEffect(y: startAnimation ? divideByZeroProtection(CGFloat.self, dataPoint.value, chartData.maxValue) : 0, anchor: .bottom)
             .scaleEffect(x: chartData.barStyle.barWidth, anchor: .center)
             .background(Color(.gray).opacity(0.000000001))
             .animateOnAppear(using: chartData.chartStyle.globalAnimation) {
@@ -148,7 +147,7 @@ internal struct GradientStopsBar<CD: CTBarChartDataProtocol & GetDataProtocol,
             .fill(LinearGradient(gradient: Gradient(stops: stops),
                                  startPoint: startPoint,
                                  endPoint: endPoint))
-            .scaleEffect(y: startAnimation ? CGFloat(dataPoint.value / chartData.maxValue) : 0, anchor: .bottom)
+            .scaleEffect(y: startAnimation ? divideByZeroProtection(CGFloat.self, dataPoint.value, chartData.maxValue) : 0, anchor: .bottom)
             .scaleEffect(x: chartData.barStyle.barWidth, anchor: .center)
             .background(Color(.gray).opacity(0.000000001))
             .animateOnAppear(using: chartData.chartStyle.globalAnimation) {
@@ -360,7 +359,7 @@ internal struct RangedBarChartColourCell<CD:RangedBarChartData>: View {
                                  bl: chartData.barStyle.cornerRadius.bottom,
                                  br: chartData.barStyle.cornerRadius.bottom)
             .fill(colour)
-            .scaleEffect(y: startAnimation ? CGFloat((dataPoint.upperValue - dataPoint.lowerValue) / chartData.range) : 0, anchor: .center)
+            .scaleEffect(y: startAnimation ? divideByZeroProtection(CGFloat.self, (dataPoint.upperValue - dataPoint.lowerValue), chartData.range) : 0, anchor: .center)
             .scaleEffect(x: chartData.barStyle.barWidth, anchor: .center)
             .position(x: barSize.midX,
                       y: chartData.getBarPositionX(dataPoint: dataPoint, height: barSize.height))
@@ -411,7 +410,7 @@ internal struct RangedBarChartColoursCell<CD:RangedBarChartData>: View {
             .fill(LinearGradient(gradient: Gradient(colors: colours),
                                  startPoint: startPoint,
                                  endPoint: endPoint))
-            .scaleEffect(y: startAnimation ? CGFloat((dataPoint.upperValue - dataPoint.lowerValue) / chartData.range) : 0, anchor: .center)
+            .scaleEffect(y: startAnimation ? divideByZeroProtection(CGFloat.self, (dataPoint.upperValue - dataPoint.lowerValue), chartData.range) : 0, anchor: .center)
             .scaleEffect(x: chartData.barStyle.barWidth, anchor: .center)
             .position(x: barSize.midX,
                       y: chartData.getBarPositionX(dataPoint: dataPoint, height: barSize.height))
@@ -462,7 +461,7 @@ internal struct RangedBarChartStopsCell<CD:RangedBarChartData>: View {
             .fill(LinearGradient(gradient: Gradient(stops: stops),
                                  startPoint: startPoint,
                                  endPoint: endPoint))
-            .scaleEffect(y: startAnimation ? CGFloat((dataPoint.upperValue - dataPoint.lowerValue) / chartData.range) : 0, anchor: .center)
+            .scaleEffect(y: startAnimation ? divideByZeroProtection(CGFloat.self, (dataPoint.upperValue - dataPoint.lowerValue), chartData.range) : 0, anchor: .center)
             .scaleEffect(x: chartData.barStyle.barWidth, anchor: .center)
             .position(x: barSize.midX,
                       y: chartData.getBarPositionX(dataPoint: dataPoint, height: barSize.height))
@@ -512,7 +511,7 @@ internal struct HorizontalColourBar<CD: CTBarChartDataProtocol & GetDataProtocol
                                  bl: chartData.barStyle.cornerRadius.bottom,
                                  br: chartData.barStyle.cornerRadius.top)
             .fill(colour)
-            .scaleEffect(x: startAnimation ? CGFloat(dataPoint.value / chartData.maxValue) : 0, anchor: .leading)
+            .scaleEffect(x: startAnimation ? divideByZeroProtection(CGFloat.self, dataPoint.value, chartData.maxValue) : 0, anchor: .leading)
             .scaleEffect(y: chartData.barStyle.barWidth, anchor: .center)
             .background(Color(.gray).opacity(0.000000001))
             .animateOnAppear(using: chartData.chartStyle.globalAnimation) {
@@ -565,7 +564,7 @@ internal struct HorizontalGradientColoursBar<CD: CTBarChartDataProtocol & GetDat
             .fill(LinearGradient(gradient: Gradient(colors: colours),
                                  startPoint: startPoint,
                                  endPoint: endPoint))
-            .scaleEffect(x: startAnimation ? CGFloat(dataPoint.value / chartData.maxValue) : 0, anchor: .leading)
+            .scaleEffect(x: startAnimation ? divideByZeroProtection(CGFloat.self, dataPoint.value, chartData.maxValue) : 0, anchor: .leading)
             .scaleEffect(y: chartData.barStyle.barWidth, anchor: .center)
             .background(Color(.gray).opacity(0.000000001))
             .animateOnAppear(using: chartData.chartStyle.globalAnimation) {
@@ -618,7 +617,7 @@ internal struct HorizontalGradientStopsBar<CD: CTBarChartDataProtocol & GetDataP
             .fill(LinearGradient(gradient: Gradient(stops: stops),
                                  startPoint: startPoint,
                                  endPoint: endPoint))
-            .scaleEffect(x: startAnimation ? CGFloat(dataPoint.value / chartData.maxValue) : 0, anchor: .leading)
+            .scaleEffect(x: startAnimation ? divideByZeroProtection(CGFloat.self, dataPoint.value, chartData.maxValue) : 0, anchor: .leading)
             .scaleEffect(y: chartData.barStyle.barWidth, anchor: .center)
             .background(Color(.gray).opacity(0.000000001))
             .animateOnAppear(using: chartData.chartStyle.globalAnimation) {

--- a/Sources/SwiftUICharts/Shared/Extras/Extensions.swift
+++ b/Sources/SwiftUICharts/Shared/Extras/Extensions.swift
@@ -118,3 +118,21 @@ extension Color {
         #endif
     }
 }
+
+// MARK: - Global Functions
+/// Protects against divide by zero.
+///
+/// Return zero in the case of divide by zero.
+/// 
+/// ```
+/// divideByZeroProtection(CGFloat.self, value, maxValue)
+/// ```
+///
+/// - Parameters:
+///   - outputType: The numeric type required as an output.
+///   - lhs: Dividend
+///   - rhs: Divisor
+/// - Returns: If rhs is not zero it returns the quotient otherwise it returns zero.
+func divideByZeroProtection<T: BinaryFloatingPoint, U: BinaryFloatingPoint>(_ outputType: U.Type, _ lhs: T, _ rhs: T) -> U {
+    U(rhs != 0 ? (lhs / rhs) : 0)
+}

--- a/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/PointOfInterestProtocol.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/PointOfInterestProtocol.swift
@@ -262,13 +262,13 @@ extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointO
     public func poiValueLabelPositionAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         let leading: CGFloat = -((self.viewData.yAxisLabelWidth.max() ?? 0) / 2) - 4 // -4 for padding at the root view.
         let trailing: CGFloat = frame.width + ((self.viewData.yAxisLabelWidth.max() ?? 0) / 2) + 4 // +4 for padding at the root view.
-        let value: CGFloat = CGFloat((markerValue - minValue) / range)
+        let value: CGFloat = divideByZeroProtection(CGFloat.self, (markerValue - minValue), range)
         return CGPoint(x: self.chartStyle.yAxisLabelPosition == .leading ? leading : trailing,
                        y: frame.height - value * frame.height)
     }
     public func poiValueLabelPositionCenter(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         CGPoint(x: frame.width / 2,
-                y: frame.height - CGFloat((markerValue - minValue) / range) * frame.height)
+                y: frame.height - divideByZeroProtection(CGFloat.self, (markerValue - minValue), range) * frame.height)
     }
 }
 
@@ -278,12 +278,12 @@ extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointO
     public func poiValueLabelPositionAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         let bottom: CGFloat = frame.height + ((self.viewData.xAxisLabelHeights.max() ?? 0) / 2) + 4  // +4 for padding at the root view
         let top: CGFloat = -((self.viewData.xAxisLabelHeights.max() ?? 0) / 2) - 4  // -4 for padding at the root view
-        let value: CGFloat = CGFloat((markerValue - minValue) / range)
+        let value: CGFloat = divideByZeroProtection(CGFloat.self, (markerValue - minValue), range)
         return CGPoint(x: value * frame.width,
                 y: self.chartStyle.xAxisLabelPosition == .bottom ? bottom : top)
     }
     public func poiValueLabelPositionCenter(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
-        CGPoint(x: CGFloat((markerValue - minValue) / range) * frame.width,
+        CGPoint(x: divideByZeroProtection(CGFloat.self, (markerValue - minValue), range) * frame.width,
                 y: frame.height / 2)
     }
 }


### PR DESCRIPTION
# Fixes
- Stop bar chart from crashing app if all data points are zero.