### PR TITLE
Enabling corner radius for left/right and explicitly setting all corners

### DIFF
--- a/Sources/SwiftUICharts/BarChart/Models/CornerRadius.swift
+++ b/Sources/SwiftUICharts/BarChart/Models/CornerRadius.swift
@@ -12,15 +12,43 @@ import SwiftUI
  */
 public struct CornerRadius: Hashable {
     
-    public let top: CGFloat
-    public let bottom: CGFloat
+    public let topLeft: CGFloat
+    public let topRight: CGFloat
+    public let bottomLeft: CGFloat
+    public let bottomRight: CGFloat
     
-    /// Set the coner radius for the bar shapes
+    /// Set the coner radius for the bar shapes for top and bottom
     public init(
         top: CGFloat = 15.0,
         bottom: CGFloat = 0.0
     ) {
-        self.top = top
-        self.bottom = bottom
+        self.topLeft = top
+        self.topRight = top
+        self.bottomLeft = bottom
+        self.bottomRight = bottom
+    }
+    
+    /// Set the coner radius for the bar shapes for left and right
+    public init(
+        left: CGFloat = 0.0,
+        right: CGFloat = 0.0
+    ) {
+        self.topLeft = left
+        self.topRight = right
+        self.bottomLeft = left
+        self.bottomRight = right
+    }
+    
+    /// Set the coner radius for the bar shapes for all corners
+    public init(
+        topLeft: CGFloat = 0,
+        topRight: CGFloat = 0,
+        bottomLeft: CGFloat = 0,
+        bottomRight: CGFloat = 0
+    ) {
+        self.topLeft = topLeft
+        self.topRight = topRight
+        self.bottomLeft = bottomLeft
+        self.bottomRight = bottomRight
     }
 }

--- a/Sources/SwiftUICharts/BarChart/Shapes/RoundedRectangleBarShape.swift
+++ b/Sources/SwiftUICharts/BarChart/Shapes/RoundedRectangleBarShape.swift
@@ -32,10 +32,10 @@ internal struct RoundedRectangleBarShape: Shape {
     }
     
     internal init(_ cornerRadius: CornerRadius) {
-        self.tl = cornerRadius.top
-        self.tr = cornerRadius.top
-        self.bl = cornerRadius.bottom
-        self.br = cornerRadius.bottom
+        self.tl = cornerRadius.topLeft
+        self.tr = cornerRadius.topRight
+        self.bl = cornerRadius.bottomLeft
+        self.br = cornerRadius.bottomRight
     }
     
     internal func path(in rect: CGRect) -> Path {


### PR DESCRIPTION
Fixes issue #157 
Allows corner radius to be set for top/bottom, left/right + explicitly all corners as well.