### PR TITLE
Add .position DisplayValue to show POI Labels at a certain position inside the chart + Custom Shapes for POI Labels

### DIFF
--- a/Sources/SwiftUICharts/SharedLineAndBar/Extras/LineAndBarEnums.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/Extras/LineAndBarEnums.swift
@@ -58,6 +58,7 @@ public enum YAxisLabelPosistion {
  case none // No label.
  case yAxis(specifier: String, formatter: NumberFormatter? = nil) // Places the label in the yAxis labels.
  case center(specifier: String, formatter: NumberFormatter? = nil) // Places the label in the center of chart.
+ case position(location: CGFloat, specifier: String, formatter: NumberFormatter? = nil) // Places the label at a relative position from leading edge.
  ```
  */
 public enum DisplayValue {
@@ -67,8 +68,8 @@ public enum DisplayValue {
     case yAxis(specifier: String, formatter: NumberFormatter? = nil)
     /// Places the label in the center of chart.
     case center(specifier: String, formatter: NumberFormatter? = nil)
-    /// Places the label at the opposite end of yAxis labels of the chart
-    case oppositeYAxis(specifier: String, formatter: NumberFormatter? = nil)
+    /// Places the label in between the graph at a certain distance from the axis,  i.e. 0 places it on the leading edge and 1 places it on the trailing edge. Defaults to 0.5 if location >1 or <0
+    case position(location: CGFloat, specifier: String, formatter: NumberFormatter? = nil)
     
 }
 

--- a/Sources/SwiftUICharts/SharedLineAndBar/Extras/LineAndBarEnums.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/Extras/LineAndBarEnums.swift
@@ -1,6 +1,6 @@
 //
 //  LineAndBarEnums.swift
-//  
+//
 //
 //  Created by Will Dale on 08/02/2021.
 //
@@ -67,6 +67,9 @@ public enum DisplayValue {
     case yAxis(specifier: String, formatter: NumberFormatter? = nil)
     /// Places the label in the center of chart.
     case center(specifier: String, formatter: NumberFormatter? = nil)
+    /// Places the label at the opposite end of yAxis labels of the chart
+    case oppositeYAxis(specifier: String, formatter: NumberFormatter? = nil)
+    
 }
 
 /**

--- a/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/PointOfInterestProtocol.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/PointOfInterestProtocol.swift
@@ -42,7 +42,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiLabelAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> LabelAxis
+    func poiLabelAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, customLabelShape: CustomLabelShape?, padding: CGFloat?) -> LabelAxis
     
     /**
      A type representing a View for displaying a label
@@ -56,21 +56,21 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiLabelCenter(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> LabelCenter
+    func poiLabelCenter(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, padding: CGFloat?) -> LabelCenter
     
     /**
      A type representing a View for displaying a label
-     as a POI at the opposite end of yAxis.
+     as a POI at a relative location from the leading axis.
      */
-    associatedtype LabelOppositeAxis: View
+    associatedtype LabelPosition: View
     /**
      Displays a label and box that mark a Point Of Interest
-     at the opposite end of yAxis.
+     at a relative location from the axis.
      
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiLabelOppositeAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> LabelOppositeAxis
+    func poiLabelPosition(location: CGFloat, markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, padding: CGFloat?) -> LabelPosition
     
     
     /**
@@ -101,7 +101,7 @@ public protocol PointOfInterestProtocol {
     
     /**
      Sets the position of the POI Label when it's at
-     the opposite end of the yAxis.
+     a relative location from the leading axis.
      
      - Parameters:
         - frame: Size of the chart.
@@ -110,7 +110,7 @@ public protocol PointOfInterestProtocol {
         - range: Difference between the highest and lowest values in the data set.
      - Returns: Position of label.
      */
-    func poiValueLabelPositionOppositeYAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint
+    func poiValueLabelRelativePosition(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint
     
     
     
@@ -147,7 +147,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiAbscissaLabelAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> AbscissaLabelAxis
+    func poiAbscissaLabelAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, customLabelShape: CustomLabelShape?, padding: CGFloat?) -> AbscissaLabelAxis
     
     /**
      A type representing a View for displaying a label
@@ -161,21 +161,21 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiAbscissaLabelCenter(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> AbscissaLabelCenter
+    func poiAbscissaLabelCenter(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, padding: CGFloat?) -> AbscissaLabelCenter
     
     /**
      A type representing a View for displaying a label
-     as a POI at the opposite end of the axis.
+     as a POI at a relative location from the leading axis.
      */
-    associatedtype AbscissaLabelOppositeAxis: View
+    associatedtype AbscissaLabelPosition: View
     /**
      Displays a label and box that mark a Point Of Interest
-     opposite of labels of axis.
+     at a relative location from the leading axis.
      
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiAbscissaLabelOppositeAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> AbscissaLabelOppositeAxis
+    func poiAbscissaLabelPosition(location: CGFloat, marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, padding: CGFloat?) -> AbscissaLabelPosition
     
     
     /**
@@ -206,7 +206,7 @@ public protocol PointOfInterestProtocol {
     
     /**
      Sets the position of the POI Label when it's at
-     the opposite side of labels of axis.
+     a relative location from the leading axis.
      
      - Parameters:
         - frame: Size of the chart.
@@ -215,7 +215,7 @@ public protocol PointOfInterestProtocol {
         - range: Difference between the highest and lowest values in the data set.
      - Returns: Position of label.
      */
-    func poiAbscissaValueLabelPositionOppositeAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint
+    func poiAbscissaValueLabelRelativePosition(frame: CGRect, markerValue: Int, count: Int) -> CGPoint
 }
 
 
@@ -247,31 +247,26 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelBackground: Color,
      labelBorderColor: Color,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?,
-     labelIcon: AnyView?
+     padding: CGFloat?
     ) -> some View {
-        Label {
-            Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
-                .font(labelFont)
-                .foregroundColor(labelColour)
-        } icon: {
-            labelIcon
-        }
-        .padding(customTextToShapePadding ?? 4)
-        .background(labelBackground)
-        .ifElse(self.chartStyle.yAxisLabelPosition == .leading, if: {
-            $0
-                .clipShape(customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
-                .overlay((customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
-                            .stroke(labelBorderColor)
-                )
-        }, else: {
-            $0
-                .clipShape(customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
-                .overlay((customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
-                            .stroke(labelBorderColor)
-                )
-        })
+        Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
+            .font(labelFont)
+            .foregroundColor(labelColour)
+            .padding(padding ?? 4)
+            .background(labelBackground)
+            .ifElse(self.chartStyle.yAxisLabelPosition == .leading, if: {
+                $0
+                    .clipShape(customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
+                                .stroke(labelBorderColor)
+                    )
+            }, else: {
+                $0
+                    .clipShape(customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
+                                .stroke(labelBorderColor)
+                    )
+            })
     }
     
    public func poiLabelCenter(
@@ -284,25 +279,21 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
     labelBorderColor: Color,
     strokeStyle: StrokeStyle,
     customLabelShape: CustomLabelShape?,
-    customTextToShapePadding: CGFloat?,
-    labelIcon: AnyView?
+    padding: CGFloat?
    ) -> some View {
-       Label {
-           Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
-               .font(labelFont)
-               .foregroundColor(labelColour)
-       } icon: {
-           labelIcon
-       }
-       .padding(.all, customTextToShapePadding)
-       .background(labelBackground)
-       .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-       .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                   .stroke(labelBorderColor, style: strokeStyle)
-       )
+       Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
+           .font(labelFont)
+           .foregroundColor(labelColour)
+           .padding(.all, padding)
+           .background(labelBackground)
+           .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+           .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                        .stroke(labelBorderColor, style: strokeStyle)
+           )
     }
     
-    public func poiLabelOppositeAxis(
+    public func poiLabelPosition(
+     location: CGFloat,
      markerValue: Double,
      specifier: String,
      formatter: NumberFormatter?,
@@ -312,30 +303,28 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelBorderColor: Color,
      strokeStyle: StrokeStyle,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?,
-     labelIcon: AnyView?
+     padding: CGFloat?
     ) -> some View {
-        HStack {
-            if self.chartStyle.yAxisLabelPosition == .leading {
-                Spacer()
-            }
-            Label {
-                Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
-                    .font(labelFont)
-                    .foregroundColor(labelColour)
-            } icon: {
-                labelIcon
-            }
-            .padding(.all, customTextToShapePadding)
-            .background(labelBackground)
-            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                        .stroke(labelBorderColor, style: strokeStyle)
-            )
+        var distanceFromLeading: CGFloat = 0.5
+        if 0...1 ~= location {
             if self.chartStyle.yAxisLabelPosition == .trailing {
-                Spacer()
+                distanceFromLeading = 1 - location
+            } else {
+                distanceFromLeading = location
             }
         }
+        
+        return PositionedPOILabel(content: {
+            Text(self.poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+                .padding(.all, padding)
+                .background(labelBackground)
+                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                            .stroke(labelBorderColor, style: strokeStyle)
+                )
+        }, orientation: .horizontal, distanceFromLeading: distanceFromLeading)
     }
 }
 extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHorizontal {
@@ -352,34 +341,30 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
      labelBackground: Color,
      labelBorderColor: Color,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?,
-     labelIcon: AnyView?
+     padding: CGFloat?
     ) -> some View {
-        Label {
-            Text(LocalizedStringKey("\(markerValue, specifier: specifier)"))
-                .font(labelFont)
-                .foregroundColor(labelColour)
-        } icon: {
-            labelIcon
-        }
-        .padding(customTextToShapePadding ?? 4)
-        .background(labelBackground)
-        .ifElse(self.chartStyle.xAxisLabelPosition == .bottom, if: {
-            $0
-                .clipShape(customLabelShape ?? CustomLabelShape(BottomLabelShape()))
-                .overlay((customLabelShape ?? CustomLabelShape(BottomLabelShape()))
-                            .stroke(labelBorderColor)
-                )
-        }, else: {
-            $0
-                .clipShape(customLabelShape ?? CustomLabelShape(TopLabelShape()))
-                .overlay((customLabelShape ?? CustomLabelShape(TopLabelShape()))
-                            .stroke(labelBorderColor)
-                )
-        })
+        Text(LocalizedStringKey("\(markerValue, specifier: specifier)"))
+            .font(labelFont)
+            .foregroundColor(labelColour)
+            .padding(padding ?? 4)
+            .background(labelBackground)
+            .ifElse(self.chartStyle.xAxisLabelPosition == .bottom, if: {
+                $0
+                    .clipShape(customLabelShape ?? CustomLabelShape(BottomLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(BottomLabelShape()))
+                                .stroke(labelBorderColor)
+                    )
+            }, else: {
+                $0
+                    .clipShape(customLabelShape ?? CustomLabelShape(TopLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(TopLabelShape()))
+                                .stroke(labelBorderColor)
+                    )
+            })
     }
     
-    public func poiLabelOppositeAxis(
+    public func poiLabelPosition(
+     location: CGFloat,
      markerValue: Double,
      specifier: String,
      formatter: NumberFormatter?,
@@ -389,30 +374,29 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
      labelBorderColor: Color,
      strokeStyle: StrokeStyle,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?,
-     labelIcon: AnyView?
+     padding: CGFloat?
     ) -> some View {
-        VStack {
-            if self.chartStyle.xAxisLabelPosition == .top {
-                Spacer()
-            }
-            Label {
-                Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
-                    .font(labelFont)
-                    .foregroundColor(labelColour)
-            } icon: {
-                labelIcon
-            }
-            .padding(.all, customTextToShapePadding)
-            .background(labelBackground)
-            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                        .stroke(labelBorderColor, style: strokeStyle)
-            )
+        
+        var distanceFromLeading: CGFloat = 0.5
+        if 0...1 ~= location {
             if self.chartStyle.xAxisLabelPosition == .bottom {
-                Spacer()
+                distanceFromLeading = 1 - location
+            } else {
+                distanceFromLeading = location
             }
         }
+        
+        return PositionedPOILabel(content: {
+            Text(self.poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+                .padding(.all, padding)
+                .background(labelBackground)
+                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                            .stroke(labelBorderColor, style: strokeStyle)
+                )
+        }, orientation: .vertical, distanceFromLeading: distanceFromLeading)
     }
 }
 
@@ -439,7 +423,7 @@ extension CTLineBarChartDataProtocol where Self: CTLineChartDataProtocol & Point
                 y: CGFloat(markerValue - minValue) * -(frame.height / CGFloat(range)) + frame.height)
     }
     
-    public func poiValueLabelPositionOppositeYAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
+    public func poiValueLabelRelativePosition(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         let value: CGFloat = CGFloat(markerValue - minValue)
         let sizing: CGFloat = -(frame.height / CGFloat(range))
         return CGPoint(x: frame.width / 2,
@@ -463,7 +447,7 @@ extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointO
                 y: frame.height - divideByZeroProtection(CGFloat.self, (markerValue - minValue), range) * frame.height)
     }
     
-    public func poiValueLabelPositionOppositeYAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
+    public func poiValueLabelRelativePosition(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         let value: CGFloat = CGFloat(markerValue - minValue)
         let sizing: CGFloat = -(frame.height / CGFloat(range))
         return CGPoint(x: frame.width / 2,
@@ -488,7 +472,7 @@ extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointO
                 y: frame.height / 2)
     }
     
-    public func poiValueLabelPositionOppositeYAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
+    public func poiValueLabelRelativePosition(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         let value: CGFloat = divideByZeroProtection(CGFloat.self, (markerValue - minValue), range)
         return CGPoint(x: value * frame.width,
                 y: frame.height / 2)
@@ -514,23 +498,18 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelBackground: Color,
      labelBorderColor: Color,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?,
-     labelIcon: AnyView?
+     padding: CGFloat?
     ) -> some View {
-        Label {
-            Text(LocalizedStringKey(marker))
-                .font(labelFont)
-                .foregroundColor(labelColour)
-        } icon: {
-            labelIcon
-        }
-        .padding(customTextToShapePadding ?? 4)
-        .padding(.vertical, 4)
-        .background(labelBackground)
-        .clipShape(customLabelShape ?? CustomLabelShape(RoundedRectangle(cornerRadius: 5, style: .continuous)))
-        .overlay((customLabelShape ?? CustomLabelShape(RoundedRectangle(cornerRadius: 5, style: .continuous)))
-                    .stroke(labelBorderColor)
-        )
+        Text(LocalizedStringKey(marker))
+            .font(labelFont)
+            .foregroundColor(labelColour)
+            .padding(padding ?? 4)
+            .padding(.vertical, 4)
+            .background(labelBackground)
+            .clipShape(customLabelShape ?? CustomLabelShape(RoundedRectangle(cornerRadius: 5, style: .continuous)))
+            .overlay((customLabelShape ?? CustomLabelShape(RoundedRectangle(cornerRadius: 5, style: .continuous)))
+                        .stroke(labelBorderColor)
+            )
     }
     
     public func poiAbscissaLabelCenter(
@@ -541,25 +520,21 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelBorderColor: Color,
      strokeStyle: StrokeStyle,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?,
-     labelIcon: AnyView?
+     padding: CGFloat?
     ) -> some View {
-        Label {
-            Text(LocalizedStringKey(marker))
-                .font(labelFont)
-                .foregroundColor(labelColour)
-        } icon: {
-            labelIcon
-        }
-        .padding(.all, customTextToShapePadding)
-        .background(labelBackground)
-        .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-        .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                    .stroke(labelBorderColor, style: strokeStyle)
-        )
+        Text(LocalizedStringKey(marker))
+            .font(labelFont)
+            .foregroundColor(labelColour)
+            .padding(.all, padding)
+            .background(labelBackground)
+            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                        .stroke(labelBorderColor, style: strokeStyle)
+            )
     }
     
-    public func poiAbscissaLabelOppositeAxis(
+    public func poiAbscissaLabelPosition(
+     location: CGFloat,
      marker: String,
      labelFont: Font,
      labelColour: Color,
@@ -567,30 +542,28 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelBorderColor: Color,
      strokeStyle: StrokeStyle,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?,
-     labelIcon: AnyView?
+     padding: CGFloat?
     ) -> some View {
-        VStack {
-            if self.chartStyle.xAxisLabelPosition == .top {
-                Spacer()
-            }
-            Label {
-                Text(LocalizedStringKey(marker))
-                    .font(labelFont)
-                    .foregroundColor(labelColour)
-            } icon: {
-                labelIcon
-            }
-            .padding(.all, customTextToShapePadding)
-            .background(labelBackground)
-            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                        .stroke(labelBorderColor, style: strokeStyle)
-            )
+        var distanceFromLeading: CGFloat = 0.5
+        if 0...1 ~= location {
             if self.chartStyle.xAxisLabelPosition == .bottom {
-                Spacer()
+                distanceFromLeading = 1 - location
+            } else {
+                distanceFromLeading = location
             }
         }
+        
+        return PositionedPOILabel(content: {
+            Text(LocalizedStringKey(marker))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+                .padding(.all, padding)
+                .background(labelBackground)
+                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                            .stroke(labelBorderColor, style: strokeStyle)
+                )
+        }, orientation: .vertical, distanceFromLeading: distanceFromLeading)
     }
 }
 
@@ -607,34 +580,30 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
      labelBackground: Color,
      labelBorderColor: Color,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?,
-     labelIcon: AnyView?
+     padding: CGFloat?
     ) -> some View {
-        Label {
-            Text(LocalizedStringKey(marker))
-                .font(labelFont)
-                .foregroundColor(labelColour)
-        } icon: {
-            labelIcon
-        }
-        .padding(customTextToShapePadding ?? 4)
-        .background(labelBackground)
-        .ifElse(self.chartStyle.yAxisLabelPosition == .leading, if: {
-            $0
-                .clipShape(customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
-                .overlay((customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
-                            .stroke(labelBorderColor)
-                )
-        }, else: {
-            $0
-                .clipShape(customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
-                .overlay((customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
-                            .stroke(labelBorderColor)
-                )
-        })
+        Text(LocalizedStringKey(marker))
+            .font(labelFont)
+            .foregroundColor(labelColour)
+            .padding(padding ?? 4)
+            .background(labelBackground)
+            .ifElse(self.chartStyle.yAxisLabelPosition == .leading, if: {
+                $0
+                    .clipShape(customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
+                                .stroke(labelBorderColor)
+                    )
+            }, else: {
+                $0
+                    .clipShape(customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
+                                .stroke(labelBorderColor)
+                    )
+            })
     }
     
-    public func poiAbscissaLabelOppositeAxis(
+    public func poiAbscissaLabelPosition(
+     location: CGFloat,
      marker: String,
      labelFont: Font,
      labelColour: Color,
@@ -642,30 +611,28 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
      labelBorderColor: Color,
      strokeStyle: StrokeStyle,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?,
-     labelIcon: AnyView?
+     padding: CGFloat?
     ) -> some View {
-        HStack {
-            if self.chartStyle.yAxisLabelPosition == .leading {
-                Spacer()
-            }
-            Label {
-                Text(LocalizedStringKey(marker))
-                    .font(labelFont)
-                    .foregroundColor(labelColour)
-            } icon: {
-                labelIcon
-            }
-            .padding(.all, customTextToShapePadding)
-            .background(labelBackground)
-            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                        .stroke(labelBorderColor, style: strokeStyle)
-            )
+        var distanceFromLeading: CGFloat = 0.5
+        if 0...1 ~= location {
             if self.chartStyle.yAxisLabelPosition == .trailing {
-                Spacer()
+                distanceFromLeading = 1 - location
+            } else {
+                distanceFromLeading = location
             }
         }
+        
+        return PositionedPOILabel(content: {
+            Text(LocalizedStringKey(marker))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+                .padding(.all, padding)
+                .background(labelBackground)
+                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                            .stroke(labelBorderColor, style: strokeStyle)
+                )
+        }, orientation: .horizontal, distanceFromLeading: distanceFromLeading)
     }
 }
 
@@ -690,7 +657,7 @@ extension CTLineBarChartDataProtocol where Self: CTLineChartDataProtocol & Point
                 y: frame.height / 2)
     }
     
-    public func poiAbscissaValueLabelPositionOppositeAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
+    public func poiAbscissaValueLabelRelativePosition(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
         CGPoint(x: (frame.width / CGFloat(count-1)) * CGFloat(markerValue),
                 y: frame.height / 2)
     }
@@ -711,7 +678,7 @@ extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointO
                 y: frame.height / 2)
     }
     
-    public func poiAbscissaValueLabelPositionOppositeAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
+    public func poiAbscissaValueLabelRelativePosition(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
         CGPoint(x: (frame.width / CGFloat(count)) * CGFloat(markerValue) + ((frame.width / CGFloat(count)) / 2),
                 y: frame.height / 2)
     }
@@ -733,7 +700,7 @@ extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointO
                 y: ((frame.height / CGFloat(count)) * CGFloat(markerValue) + ((frame.height / CGFloat(count)) / 2)))
     }
     
-    public func poiAbscissaValueLabelPositionOppositeAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
+    public func poiAbscissaValueLabelRelativePosition(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
         CGPoint(x: frame.width / 2,
                 y: ((frame.height / CGFloat(count)) * CGFloat(markerValue) + ((frame.height / CGFloat(count)) / 2)))
     }

--- a/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/PointOfInterestProtocol.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/PointOfInterestProtocol.swift
@@ -1,6 +1,6 @@
 //
 //  PointOfInterestProtocol.swift
-//  
+//
 //
 //  Created by Will Dale on 11/06/2021.
 //
@@ -58,6 +58,20 @@ public protocol PointOfInterestProtocol {
      */
     func poiLabelCenter(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> LabelCenter
     
+    /**
+     A type representing a View for displaying a label
+     as a POI at the opposite end of yAxis.
+     */
+    associatedtype LabelOppositeAxis: View
+    /**
+     Displays a label and box that mark a Point Of Interest
+     at the opposite end of yAxis.
+     
+     In standard charts this will display leading or trailing.
+     In horizontal charts this will display bottom or top.
+     */
+    func poiLabelOppositeAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> LabelOppositeAxis
+    
     
     /**
      Sets the position of the POI Label when it's over
@@ -85,7 +99,18 @@ public protocol PointOfInterestProtocol {
      */
     func poiValueLabelPositionCenter(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint
     
-    
+    /**
+     Sets the position of the POI Label when it's at
+     the opposite end of the yAxis.
+     
+     - Parameters:
+        - frame: Size of the chart.
+        - markerValue: Value of the POI marker.
+        - minValue: Lowest value in the data set.
+        - range: Difference between the highest and lowest values in the data set.
+     - Returns: Position of label.
+     */
+    func poiValueLabelPositionOppositeYAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint
     
     
     
@@ -138,6 +163,20 @@ public protocol PointOfInterestProtocol {
      */
     func poiAbscissaLabelCenter(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> AbscissaLabelCenter
     
+    /**
+     A type representing a View for displaying a label
+     as a POI at the opposite end of the axis.
+     */
+    associatedtype AbscissaLabelOppositeAxis: View
+    /**
+     Displays a label and box that mark a Point Of Interest
+     opposite of labels of axis.
+     
+     In standard charts this will display leading or trailing.
+     In horizontal charts this will display bottom or top.
+     */
+    func poiAbscissaLabelOppositeAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> AbscissaLabelOppositeAxis
+    
     
     /**
      Sets the position of the POI Label when it's over
@@ -164,6 +203,19 @@ public protocol PointOfInterestProtocol {
      - Returns: Position of label.
      */
     func poiAbscissaValueLabelPositionCenter(frame: CGRect, markerValue: Int, count: Int) -> CGPoint
+    
+    /**
+     Sets the position of the POI Label when it's at
+     the opposite side of labels of axis.
+     
+     - Parameters:
+        - frame: Size of the chart.
+        - markerValue: Value of the POI marker.
+        - minValue: Lowest value in the data set.
+        - range: Difference between the highest and lowest values in the data set.
+     - Returns: Position of label.
+     */
+    func poiAbscissaValueLabelPositionOppositeAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint
 }
 
 
@@ -235,11 +287,42 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
                         .stroke(lineColour, style: strokeStyle)
             )
     }
+    
+    public func poiLabelOppositeAxis(
+     markerValue: Double,
+     specifier: String,
+     formatter: NumberFormatter?,
+     labelFont: Font,
+     labelColour: Color,
+     labelBackground: Color,
+     lineColour: Color,
+     strokeStyle: StrokeStyle
+    ) -> some View {
+        HStack {
+            if self.chartStyle.yAxisLabelPosition == .leading {
+                Spacer()
+            }
+            Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+                .padding()
+                .background(labelBackground)
+                .clipShape(DiamondShape())
+                .overlay(DiamondShape()
+                            .stroke(lineColour, style: strokeStyle)
+                )
+            if self.chartStyle.yAxisLabelPosition == .trailing {
+                Spacer()
+            }
+        }
+    }
 }
 extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHorizontal {
+    
     public func poiMarker(value: Double, range: Double, minValue: Double) -> some Shape {
         VerticalMarker(chartData: self, value: value, range: range, minValue: minValue)
     }
+    
     public func poiLabelAxis(markerValue: Double, specifier: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color) -> some View {
         Text(LocalizedStringKey("\(markerValue, specifier: specifier)"))
             .font(labelFont)
@@ -260,6 +343,35 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
                     )
             })
     }
+    
+    public func poiLabelOppositeAxis(
+     markerValue: Double,
+     specifier: String,
+     formatter: NumberFormatter?,
+     labelFont: Font,
+     labelColour: Color,
+     labelBackground: Color,
+     lineColour: Color,
+     strokeStyle: StrokeStyle
+    ) -> some View {
+        VStack {
+            if self.chartStyle.xAxisLabelPosition == .top {
+                Spacer()
+            }
+            Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+                .padding()
+                .background(labelBackground)
+                .clipShape(DiamondShape())
+                .overlay(DiamondShape()
+                            .stroke(lineColour, style: strokeStyle)
+                )
+            if self.chartStyle.xAxisLabelPosition == .bottom {
+                Spacer()
+            }
+        }
+    }
 }
 
 
@@ -270,6 +382,7 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
 //
 // MARK: Line Charts
 extension CTLineBarChartDataProtocol where Self: CTLineChartDataProtocol & PointOfInterestProtocol {
+    
     public func poiValueLabelPositionAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         let leading: CGFloat = -((self.viewData.yAxisLabelWidth.max() ?? 0) / 2) - 4 // -4 for padding at the root view.
         let trailing: CGFloat = frame.width + ((self.viewData.yAxisLabelWidth.max() ?? 0) / 2) + 4 // +4 for padding at the root view.
@@ -278,14 +391,23 @@ extension CTLineBarChartDataProtocol where Self: CTLineChartDataProtocol & Point
         return CGPoint(x: self.chartStyle.yAxisLabelPosition == .leading ? leading : trailing,
                        y: value * sizing + frame.height)
     }
+    
     public func poiValueLabelPositionCenter(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         CGPoint(x: frame.width / 2,
                 y: CGFloat(markerValue - minValue) * -(frame.height / CGFloat(range)) + frame.height)
+    }
+    
+    public func poiValueLabelPositionOppositeYAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
+        let value: CGFloat = CGFloat(markerValue - minValue)
+        let sizing: CGFloat = -(frame.height / CGFloat(range))
+        return CGPoint(x: frame.width / 2,
+                       y: value * sizing + frame.height)
     }
 }
 
 // MARK: Vertical Bar Charts
 extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointOfInterestProtocol {
+    
     public func poiValueLabelPositionAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         let leading: CGFloat = -((self.viewData.yAxisLabelWidth.max() ?? 0) / 2) - 4 // -4 for padding at the root view.
         let trailing: CGFloat = frame.width + ((self.viewData.yAxisLabelWidth.max() ?? 0) / 2) + 4 // +4 for padding at the root view.
@@ -293,15 +415,24 @@ extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointO
         return CGPoint(x: self.chartStyle.yAxisLabelPosition == .leading ? leading : trailing,
                        y: frame.height - value * frame.height)
     }
+    
     public func poiValueLabelPositionCenter(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         CGPoint(x: frame.width / 2,
                 y: frame.height - divideByZeroProtection(CGFloat.self, (markerValue - minValue), range) * frame.height)
+    }
+    
+    public func poiValueLabelPositionOppositeYAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
+        let value: CGFloat = CGFloat(markerValue - minValue)
+        let sizing: CGFloat = -(frame.height / CGFloat(range))
+        return CGPoint(x: frame.width / 2,
+                       y: value * sizing + frame.height)
     }
 }
 
 // MARK: Horizontal Bar Charts
 extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointOfInterestProtocol,
                                            Self: isHorizontal {
+    
     public func poiValueLabelPositionAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         let bottom: CGFloat = frame.height + ((self.viewData.xAxisLabelHeights.max() ?? 0) / 2) + 4  // +4 for padding at the root view
         let top: CGFloat = -((self.viewData.xAxisLabelHeights.max() ?? 0) / 2) - 4  // -4 for padding at the root view
@@ -309,8 +440,15 @@ extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointO
         return CGPoint(x: value * frame.width,
                 y: self.chartStyle.xAxisLabelPosition == .bottom ? bottom : top)
     }
+    
     public func poiValueLabelPositionCenter(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
         CGPoint(x: divideByZeroProtection(CGFloat.self, (markerValue - minValue), range) * frame.width,
+                y: frame.height / 2)
+    }
+    
+    public func poiValueLabelPositionOppositeYAxis(frame: CGRect, markerValue: Double, minValue: Double, range: Double) -> CGPoint {
+        let value: CGFloat = divideByZeroProtection(CGFloat.self, (markerValue - minValue), range)
+        return CGPoint(x: value * frame.width,
                 y: frame.height / 2)
     }
 }
@@ -322,9 +460,11 @@ extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointO
 
 // MARK: - Abscissa
 extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
+    
     public func poiAbscissaMarker(markerValue: Int, dataPointCount: Int) -> some Shape {
         VerticalAbscissaMarker(chartData: self, markerValue: markerValue, dataPointCount: dataPointCount)
     }
+    
     public func poiAbscissaLabelAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color) -> some View {
         Text(LocalizedStringKey(marker))
             .font(labelFont)
@@ -337,6 +477,7 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
                         .stroke(lineColour)
             )
     }
+    
     public func poiAbscissaLabelCenter(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> some View {
         Text(LocalizedStringKey(marker))
             .font(labelFont)
@@ -348,12 +489,34 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
                         .stroke(lineColour, style: strokeStyle)
             )
     }
+    
+    public func poiAbscissaLabelOppositeAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> some View {
+        VStack {
+            if self.chartStyle.xAxisLabelPosition == .top {
+                Spacer()
+            }
+            Text(LocalizedStringKey(marker))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+                .padding()
+                .background(labelBackground)
+                .clipShape(DiamondShape())
+                .overlay(DiamondShape()
+                            .stroke(lineColour, style: strokeStyle)
+                )
+            if self.chartStyle.xAxisLabelPosition == .bottom {
+                Spacer()
+            }
+        }
+    }
 }
 
 extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHorizontal {
+    
     public func poiAbscissaMarker(markerValue: Int, dataPointCount: Int) -> some Shape {
         HorizontalAbscissaMarker(chartData: self, markerValue: markerValue, dataPointCount: dataPointCount)
     }
+    
     public func poiAbscissaLabelAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color) -> some View {
         Text(LocalizedStringKey(marker))
             .font(labelFont)
@@ -374,6 +537,26 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
                     )
             })
     }
+    
+    public func poiAbscissaLabelOppositeAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> some View {
+        HStack {
+            if self.chartStyle.yAxisLabelPosition == .leading {
+                Spacer()
+            }
+            Text(LocalizedStringKey(marker))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+                .padding()
+                .background(labelBackground)
+                .clipShape(DiamondShape())
+                .overlay(DiamondShape()
+                            .stroke(lineColour, style: strokeStyle)
+                )
+            if self.chartStyle.yAxisLabelPosition == .trailing {
+                Spacer()
+            }
+        }
+    }
 }
 
 
@@ -384,13 +567,20 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
 //
 // MARK: Line Charts
 extension CTLineBarChartDataProtocol where Self: CTLineChartDataProtocol & PointOfInterestProtocol {
+    
     public func poiAbscissaValueLabelPositionAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
         let bottom: CGFloat = frame.height + ((self.viewData.xAxisLabelHeights.max() ?? 0) / 2) + 10  // +4 for padding at the root view
         let top: CGFloat = -((self.viewData.xAxisLabelHeights.max() ?? 0) / 2) - 10  // -4 for padding at the root view
         return CGPoint(x: (frame.width / CGFloat(count-1)) * CGFloat(markerValue),
                        y: self.chartStyle.xAxisLabelPosition == .bottom ? bottom : top)
     }
+    
     public func poiAbscissaValueLabelPositionCenter(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
+        CGPoint(x: (frame.width / CGFloat(count-1)) * CGFloat(markerValue),
+                y: frame.height / 2)
+    }
+    
+    public func poiAbscissaValueLabelPositionOppositeAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
         CGPoint(x: (frame.width / CGFloat(count-1)) * CGFloat(markerValue),
                 y: frame.height / 2)
     }
@@ -398,13 +588,20 @@ extension CTLineBarChartDataProtocol where Self: CTLineChartDataProtocol & Point
 
 // MARK: Vertical Bar Charts
 extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointOfInterestProtocol {
+    
     public func poiAbscissaValueLabelPositionAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
         let bottom: CGFloat = frame.height + ((self.viewData.xAxisLabelHeights.max() ?? 0) / 2) + 10  // +4 for padding at the root view
         let top: CGFloat = -((self.viewData.xAxisLabelHeights.max() ?? 0) / 2) - 10  // -4 for padding at the root view
         return CGPoint(x: (frame.width / CGFloat(count-1)) * CGFloat(markerValue),
                        y: self.chartStyle.xAxisLabelPosition == .bottom ? bottom : top)
     }
+    
     public func poiAbscissaValueLabelPositionCenter(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
+        CGPoint(x: (frame.width / CGFloat(count)) * CGFloat(markerValue) + ((frame.width / CGFloat(count)) / 2),
+                y: frame.height / 2)
+    }
+    
+    public func poiAbscissaValueLabelPositionOppositeAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
         CGPoint(x: (frame.width / CGFloat(count)) * CGFloat(markerValue) + ((frame.width / CGFloat(count)) / 2),
                 y: frame.height / 2)
     }
@@ -413,13 +610,20 @@ extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointO
 // MARK: Horizontal Bar Charts
 extension CTLineBarChartDataProtocol where Self: CTBarChartDataProtocol & PointOfInterestProtocol,
                                            Self: isHorizontal {
+    
     public func poiAbscissaValueLabelPositionAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
         let leading: CGFloat = -((self.viewData.xAxisLabelHeights.max() ?? 0) / 2) - 8  // -4 for padding at the root view
         let trailing: CGFloat = frame.width + ((self.viewData.xAxislabelWidths.max() ?? 0) / 2) + 8  // +4 for padding at the root view
         return CGPoint(x: self.chartStyle.yAxisLabelPosition == .leading ? leading : trailing,
                        y: ((frame.height / CGFloat(count)) * CGFloat(markerValue) + ((frame.height / CGFloat(count)) / 2)))
     }
+    
     public func poiAbscissaValueLabelPositionCenter(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
+        CGPoint(x: frame.width / 2,
+                y: ((frame.height / CGFloat(count)) * CGFloat(markerValue) + ((frame.height / CGFloat(count)) / 2)))
+    }
+    
+    public func poiAbscissaValueLabelPositionOppositeAxis(frame: CGRect, markerValue: Int, count: Int) -> CGPoint {
         CGPoint(x: frame.width / 2,
                 y: ((frame.height / CGFloat(count)) * CGFloat(markerValue) + ((frame.height / CGFloat(count)) / 2)))
     }

--- a/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/PointOfInterestProtocol.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/PointOfInterestProtocol.swift
@@ -42,7 +42,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiLabelAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> LabelAxis
+    func poiLabelAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> LabelAxis
     
     /**
      A type representing a View for displaying a label
@@ -56,7 +56,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiLabelCenter(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> LabelCenter
+    func poiLabelCenter(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> LabelCenter
     
     /**
      A type representing a View for displaying a label
@@ -70,7 +70,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiLabelOppositeAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> LabelOppositeAxis
+    func poiLabelOppositeAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> LabelOppositeAxis
     
     
     /**
@@ -147,7 +147,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiAbscissaLabelAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> AbscissaLabelAxis
+    func poiAbscissaLabelAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> AbscissaLabelAxis
     
     /**
      A type representing a View for displaying a label
@@ -161,7 +161,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiAbscissaLabelCenter(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> AbscissaLabelCenter
+    func poiAbscissaLabelCenter(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> AbscissaLabelCenter
     
     /**
      A type representing a View for displaying a label
@@ -175,7 +175,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiAbscissaLabelOppositeAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> AbscissaLabelOppositeAxis
+    func poiAbscissaLabelOppositeAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, labelBorderColor: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?, labelIcon: AnyView?) -> AbscissaLabelOppositeAxis
     
     
     /**
@@ -245,28 +245,33 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelFont: Font,
      labelColour: Color,
      labelBackground: Color,
-     lineColour: Color,
+     labelBorderColor: Color,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?
+     customTextToShapePadding: CGFloat?,
+     labelIcon: AnyView?
     ) -> some View {
-        Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
-            .font(labelFont)
-            .foregroundColor(labelColour)
-            .padding(customTextToShapePadding ?? 4)
-            .background(labelBackground)
-            .ifElse(self.chartStyle.yAxisLabelPosition == .leading, if: {
-                $0
-                    .clipShape(customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
-                    .overlay((customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
-                                .stroke(lineColour)
-                    )
-            }, else: {
-                $0
-                    .clipShape(customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
-                    .overlay((customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
-                                .stroke(lineColour)
-                    )
-            })
+        Label {
+            Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+        } icon: {
+            labelIcon
+        }
+        .padding(customTextToShapePadding ?? 4)
+        .background(labelBackground)
+        .ifElse(self.chartStyle.yAxisLabelPosition == .leading, if: {
+            $0
+                .clipShape(customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
+                            .stroke(labelBorderColor)
+                )
+        }, else: {
+            $0
+                .clipShape(customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
+                            .stroke(labelBorderColor)
+                )
+        })
     }
     
    public func poiLabelCenter(
@@ -276,20 +281,25 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
     labelFont: Font,
     labelColour: Color,
     labelBackground: Color,
-    lineColour: Color,
+    labelBorderColor: Color,
     strokeStyle: StrokeStyle,
     customLabelShape: CustomLabelShape?,
-    customTextToShapePadding: CGFloat?
+    customTextToShapePadding: CGFloat?,
+    labelIcon: AnyView?
    ) -> some View {
-        Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
-            .font(labelFont)
-            .foregroundColor(labelColour)
-            .padding(.all, customTextToShapePadding)
-            .background(labelBackground)
-            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                        .stroke(lineColour, style: strokeStyle)
-            )
+       Label {
+           Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
+               .font(labelFont)
+               .foregroundColor(labelColour)
+       } icon: {
+           labelIcon
+       }
+       .padding(.all, customTextToShapePadding)
+       .background(labelBackground)
+       .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+       .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                   .stroke(labelBorderColor, style: strokeStyle)
+       )
     }
     
     public func poiLabelOppositeAxis(
@@ -299,24 +309,29 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelFont: Font,
      labelColour: Color,
      labelBackground: Color,
-     lineColour: Color,
+     labelBorderColor: Color,
      strokeStyle: StrokeStyle,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?
+     customTextToShapePadding: CGFloat?,
+     labelIcon: AnyView?
     ) -> some View {
         HStack {
             if self.chartStyle.yAxisLabelPosition == .leading {
                 Spacer()
             }
-            Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
-                .font(labelFont)
-                .foregroundColor(labelColour)
-                .padding(.all, customTextToShapePadding)
-                .background(labelBackground)
-                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                            .stroke(lineColour, style: strokeStyle)
-                )
+            Label {
+                Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
+                    .font(labelFont)
+                    .foregroundColor(labelColour)
+            } icon: {
+                labelIcon
+            }
+            .padding(.all, customTextToShapePadding)
+            .background(labelBackground)
+            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                        .stroke(labelBorderColor, style: strokeStyle)
+            )
             if self.chartStyle.yAxisLabelPosition == .trailing {
                 Spacer()
             }
@@ -335,28 +350,33 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
      labelFont: Font,
      labelColour: Color,
      labelBackground: Color,
-     lineColour: Color,
+     labelBorderColor: Color,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?
+     customTextToShapePadding: CGFloat?,
+     labelIcon: AnyView?
     ) -> some View {
-        Text(LocalizedStringKey("\(markerValue, specifier: specifier)"))
-            .font(labelFont)
-            .foregroundColor(labelColour)
-            .padding(customTextToShapePadding ?? 4)
-            .background(labelBackground)
-            .ifElse(self.chartStyle.xAxisLabelPosition == .bottom, if: {
-                $0
-                    .clipShape(customLabelShape ?? CustomLabelShape(BottomLabelShape()))
-                    .overlay((customLabelShape ?? CustomLabelShape(BottomLabelShape()))
-                                .stroke(lineColour)
-                    )
-            }, else: {
-                $0
-                    .clipShape(customLabelShape ?? CustomLabelShape(TopLabelShape()))
-                    .overlay((customLabelShape ?? CustomLabelShape(TopLabelShape()))
-                                .stroke(lineColour)
-                    )
-            })
+        Label {
+            Text(LocalizedStringKey("\(markerValue, specifier: specifier)"))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+        } icon: {
+            labelIcon
+        }
+        .padding(customTextToShapePadding ?? 4)
+        .background(labelBackground)
+        .ifElse(self.chartStyle.xAxisLabelPosition == .bottom, if: {
+            $0
+                .clipShape(customLabelShape ?? CustomLabelShape(BottomLabelShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(BottomLabelShape()))
+                            .stroke(labelBorderColor)
+                )
+        }, else: {
+            $0
+                .clipShape(customLabelShape ?? CustomLabelShape(TopLabelShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(TopLabelShape()))
+                            .stroke(labelBorderColor)
+                )
+        })
     }
     
     public func poiLabelOppositeAxis(
@@ -366,24 +386,29 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
      labelFont: Font,
      labelColour: Color,
      labelBackground: Color,
-     lineColour: Color,
+     labelBorderColor: Color,
      strokeStyle: StrokeStyle,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?
+     customTextToShapePadding: CGFloat?,
+     labelIcon: AnyView?
     ) -> some View {
         VStack {
             if self.chartStyle.xAxisLabelPosition == .top {
                 Spacer()
             }
-            Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
-                .font(labelFont)
-                .foregroundColor(labelColour)
-                .padding(.all, customTextToShapePadding)
-                .background(labelBackground)
-                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                            .stroke(lineColour, style: strokeStyle)
-                )
+            Label {
+                Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
+                    .font(labelFont)
+                    .foregroundColor(labelColour)
+            } icon: {
+                labelIcon
+            }
+            .padding(.all, customTextToShapePadding)
+            .background(labelBackground)
+            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                        .stroke(labelBorderColor, style: strokeStyle)
+            )
             if self.chartStyle.xAxisLabelPosition == .bottom {
                 Spacer()
             }
@@ -487,20 +512,25 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelFont: Font,
      labelColour: Color,
      labelBackground: Color,
-     lineColour: Color,
+     labelBorderColor: Color,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?
+     customTextToShapePadding: CGFloat?,
+     labelIcon: AnyView?
     ) -> some View {
-        Text(LocalizedStringKey(marker))
-            .font(labelFont)
-            .foregroundColor(labelColour)
-            .padding(customTextToShapePadding ?? 4)
-            .padding(.vertical, 4)
-            .background(labelBackground)
-            .clipShape(customLabelShape ?? CustomLabelShape(RoundedRectangle(cornerRadius: 5, style: .continuous)))
-            .overlay((customLabelShape ?? CustomLabelShape(RoundedRectangle(cornerRadius: 5, style: .continuous)))
-                        .stroke(lineColour)
-            )
+        Label {
+            Text(LocalizedStringKey(marker))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+        } icon: {
+            labelIcon
+        }
+        .padding(customTextToShapePadding ?? 4)
+        .padding(.vertical, 4)
+        .background(labelBackground)
+        .clipShape(customLabelShape ?? CustomLabelShape(RoundedRectangle(cornerRadius: 5, style: .continuous)))
+        .overlay((customLabelShape ?? CustomLabelShape(RoundedRectangle(cornerRadius: 5, style: .continuous)))
+                    .stroke(labelBorderColor)
+        )
     }
     
     public func poiAbscissaLabelCenter(
@@ -508,20 +538,25 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelFont: Font,
      labelColour: Color,
      labelBackground: Color,
-     lineColour: Color,
+     labelBorderColor: Color,
      strokeStyle: StrokeStyle,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?
+     customTextToShapePadding: CGFloat?,
+     labelIcon: AnyView?
     ) -> some View {
-        Text(LocalizedStringKey(marker))
-            .font(labelFont)
-            .foregroundColor(labelColour)
-            .padding(.all, customTextToShapePadding)
-            .background(labelBackground)
-            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                        .stroke(lineColour, style: strokeStyle)
-            )
+        Label {
+            Text(LocalizedStringKey(marker))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+        } icon: {
+            labelIcon
+        }
+        .padding(.all, customTextToShapePadding)
+        .background(labelBackground)
+        .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+        .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                    .stroke(labelBorderColor, style: strokeStyle)
+        )
     }
     
     public func poiAbscissaLabelOppositeAxis(
@@ -529,24 +564,29 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelFont: Font,
      labelColour: Color,
      labelBackground: Color,
-     lineColour: Color,
+     labelBorderColor: Color,
      strokeStyle: StrokeStyle,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?
+     customTextToShapePadding: CGFloat?,
+     labelIcon: AnyView?
     ) -> some View {
         VStack {
             if self.chartStyle.xAxisLabelPosition == .top {
                 Spacer()
             }
-            Text(LocalizedStringKey(marker))
-                .font(labelFont)
-                .foregroundColor(labelColour)
-                .padding(.all, customTextToShapePadding)
-                .background(labelBackground)
-                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                            .stroke(lineColour, style: strokeStyle)
-                )
+            Label {
+                Text(LocalizedStringKey(marker))
+                    .font(labelFont)
+                    .foregroundColor(labelColour)
+            } icon: {
+                labelIcon
+            }
+            .padding(.all, customTextToShapePadding)
+            .background(labelBackground)
+            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                        .stroke(labelBorderColor, style: strokeStyle)
+            )
             if self.chartStyle.xAxisLabelPosition == .bottom {
                 Spacer()
             }
@@ -565,28 +605,33 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
      labelFont: Font,
      labelColour: Color,
      labelBackground: Color,
-     lineColour: Color,
+     labelBorderColor: Color,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?
+     customTextToShapePadding: CGFloat?,
+     labelIcon: AnyView?
     ) -> some View {
-        Text(LocalizedStringKey(marker))
-            .font(labelFont)
-            .foregroundColor(labelColour)
-            .padding(customTextToShapePadding ?? 4)
-            .background(labelBackground)
-            .ifElse(self.chartStyle.yAxisLabelPosition == .leading, if: {
-                $0
-                    .clipShape(customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
-                    .overlay((customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
-                                .stroke(lineColour)
-                    )
-            }, else: {
-                $0
-                    .clipShape(customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
-                    .overlay((customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
-                                .stroke(lineColour)
-                    )
-            })
+        Label {
+            Text(LocalizedStringKey(marker))
+                .font(labelFont)
+                .foregroundColor(labelColour)
+        } icon: {
+            labelIcon
+        }
+        .padding(customTextToShapePadding ?? 4)
+        .background(labelBackground)
+        .ifElse(self.chartStyle.yAxisLabelPosition == .leading, if: {
+            $0
+                .clipShape(customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
+                            .stroke(labelBorderColor)
+                )
+        }, else: {
+            $0
+                .clipShape(customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
+                            .stroke(labelBorderColor)
+                )
+        })
     }
     
     public func poiAbscissaLabelOppositeAxis(
@@ -594,24 +639,29 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
      labelFont: Font,
      labelColour: Color,
      labelBackground: Color,
-     lineColour: Color,
+     labelBorderColor: Color,
      strokeStyle: StrokeStyle,
      customLabelShape: CustomLabelShape?,
-     customTextToShapePadding: CGFloat?
+     customTextToShapePadding: CGFloat?,
+     labelIcon: AnyView?
     ) -> some View {
         HStack {
             if self.chartStyle.yAxisLabelPosition == .leading {
                 Spacer()
             }
-            Text(LocalizedStringKey(marker))
-                .font(labelFont)
-                .foregroundColor(labelColour)
-                .padding(.all, customTextToShapePadding)
-                .background(labelBackground)
-                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
-                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
-                            .stroke(lineColour, style: strokeStyle)
-                )
+            Label {
+                Text(LocalizedStringKey(marker))
+                    .font(labelFont)
+                    .foregroundColor(labelColour)
+            } icon: {
+                labelIcon
+            }
+            .padding(.all, customTextToShapePadding)
+            .background(labelBackground)
+            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
+                        .stroke(labelBorderColor, style: strokeStyle)
+            )
             if self.chartStyle.yAxisLabelPosition == .trailing {
                 Spacer()
             }

--- a/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/PointOfInterestProtocol.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/Models/Protocols/PointOfInterestProtocol.swift
@@ -42,7 +42,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiLabelAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color) -> LabelAxis
+    func poiLabelAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> LabelAxis
     
     /**
      A type representing a View for displaying a label
@@ -56,7 +56,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiLabelCenter(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> LabelCenter
+    func poiLabelCenter(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> LabelCenter
     
     /**
      A type representing a View for displaying a label
@@ -70,7 +70,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiLabelOppositeAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> LabelOppositeAxis
+    func poiLabelOppositeAxis(markerValue: Double, specifier: String, formatter: NumberFormatter?, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> LabelOppositeAxis
     
     
     /**
@@ -147,7 +147,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiAbscissaLabelAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color) -> AbscissaLabelAxis
+    func poiAbscissaLabelAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> AbscissaLabelAxis
     
     /**
      A type representing a View for displaying a label
@@ -161,7 +161,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiAbscissaLabelCenter(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> AbscissaLabelCenter
+    func poiAbscissaLabelCenter(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> AbscissaLabelCenter
     
     /**
      A type representing a View for displaying a label
@@ -175,7 +175,7 @@ public protocol PointOfInterestProtocol {
      In standard charts this will display leading or trailing.
      In horizontal charts this will display bottom or top.
      */
-    func poiAbscissaLabelOppositeAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> AbscissaLabelOppositeAxis
+    func poiAbscissaLabelOppositeAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle, customLabelShape: CustomLabelShape?, customTextToShapePadding: CGFloat?) -> AbscissaLabelOppositeAxis
     
     
     /**
@@ -239,29 +239,31 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
     }
     
     public func poiLabelAxis(
-        markerValue: Double,
-        specifier: String,
-        formatter: NumberFormatter?,
-        labelFont: Font,
-        labelColour: Color,
-        labelBackground: Color,
-        lineColour: Color
+     markerValue: Double,
+     specifier: String,
+     formatter: NumberFormatter?,
+     labelFont: Font,
+     labelColour: Color,
+     labelBackground: Color,
+     lineColour: Color,
+     customLabelShape: CustomLabelShape?,
+     customTextToShapePadding: CGFloat?
     ) -> some View {
         Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
             .font(labelFont)
             .foregroundColor(labelColour)
-            .padding(4)
+            .padding(customTextToShapePadding ?? 4)
             .background(labelBackground)
             .ifElse(self.chartStyle.yAxisLabelPosition == .leading, if: {
                 $0
-                    .clipShape(LeadingLabelShape())
-                    .overlay(LeadingLabelShape()
+                    .clipShape(customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
                                 .stroke(lineColour)
                     )
             }, else: {
                 $0
-                    .clipShape(TrailingLabelShape())
-                    .overlay(TrailingLabelShape()
+                    .clipShape(customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
                                 .stroke(lineColour)
                     )
             })
@@ -275,15 +277,17 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
     labelColour: Color,
     labelBackground: Color,
     lineColour: Color,
-    strokeStyle: StrokeStyle
+    strokeStyle: StrokeStyle,
+    customLabelShape: CustomLabelShape?,
+    customTextToShapePadding: CGFloat?
    ) -> some View {
         Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
             .font(labelFont)
             .foregroundColor(labelColour)
-            .padding()
+            .padding(.all, customTextToShapePadding)
             .background(labelBackground)
-            .clipShape(DiamondShape())
-            .overlay(DiamondShape()
+            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
                         .stroke(lineColour, style: strokeStyle)
             )
     }
@@ -296,7 +300,9 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
      labelColour: Color,
      labelBackground: Color,
      lineColour: Color,
-     strokeStyle: StrokeStyle
+     strokeStyle: StrokeStyle,
+     customLabelShape: CustomLabelShape?,
+     customTextToShapePadding: CGFloat?
     ) -> some View {
         HStack {
             if self.chartStyle.yAxisLabelPosition == .leading {
@@ -305,10 +311,10 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
             Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
                 .font(labelFont)
                 .foregroundColor(labelColour)
-                .padding()
+                .padding(.all, customTextToShapePadding)
                 .background(labelBackground)
-                .clipShape(DiamondShape())
-                .overlay(DiamondShape()
+                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
                             .stroke(lineColour, style: strokeStyle)
                 )
             if self.chartStyle.yAxisLabelPosition == .trailing {
@@ -323,22 +329,31 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
         VerticalMarker(chartData: self, value: value, range: range, minValue: minValue)
     }
     
-    public func poiLabelAxis(markerValue: Double, specifier: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color) -> some View {
+    public func poiLabelAxis(
+     markerValue: Double,
+     specifier: String,
+     labelFont: Font,
+     labelColour: Color,
+     labelBackground: Color,
+     lineColour: Color,
+     customLabelShape: CustomLabelShape?,
+     customTextToShapePadding: CGFloat?
+    ) -> some View {
         Text(LocalizedStringKey("\(markerValue, specifier: specifier)"))
             .font(labelFont)
             .foregroundColor(labelColour)
-            .padding(4)
+            .padding(customTextToShapePadding ?? 4)
             .background(labelBackground)
             .ifElse(self.chartStyle.xAxisLabelPosition == .bottom, if: {
                 $0
-                    .clipShape(BottomLabelShape())
-                    .overlay(BottomLabelShape()
+                    .clipShape(customLabelShape ?? CustomLabelShape(BottomLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(BottomLabelShape()))
                                 .stroke(lineColour)
                     )
             }, else: {
                 $0
-                    .clipShape(TopLabelShape())
-                    .overlay(TopLabelShape()
+                    .clipShape(customLabelShape ?? CustomLabelShape(TopLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(TopLabelShape()))
                                 .stroke(lineColour)
                     )
             })
@@ -352,7 +367,9 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
      labelColour: Color,
      labelBackground: Color,
      lineColour: Color,
-     strokeStyle: StrokeStyle
+     strokeStyle: StrokeStyle,
+     customLabelShape: CustomLabelShape?,
+     customTextToShapePadding: CGFloat?
     ) -> some View {
         VStack {
             if self.chartStyle.xAxisLabelPosition == .top {
@@ -361,10 +378,10 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
             Text(poiLabel(value: markerValue, specifier: specifier, formatter: formatter))
                 .font(labelFont)
                 .foregroundColor(labelColour)
-                .padding()
+                .padding(.all, customTextToShapePadding)
                 .background(labelBackground)
-                .clipShape(DiamondShape())
-                .overlay(DiamondShape()
+                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
                             .stroke(lineColour, style: strokeStyle)
                 )
             if self.chartStyle.xAxisLabelPosition == .bottom {
@@ -465,32 +482,58 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
         VerticalAbscissaMarker(chartData: self, markerValue: markerValue, dataPointCount: dataPointCount)
     }
     
-    public func poiAbscissaLabelAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color) -> some View {
+    public func poiAbscissaLabelAxis(
+     marker: String,
+     labelFont: Font,
+     labelColour: Color,
+     labelBackground: Color,
+     lineColour: Color,
+     customLabelShape: CustomLabelShape?,
+     customTextToShapePadding: CGFloat?
+    ) -> some View {
         Text(LocalizedStringKey(marker))
             .font(labelFont)
             .foregroundColor(labelColour)
-            .padding(4)
+            .padding(customTextToShapePadding ?? 4)
             .padding(.vertical, 4)
             .background(labelBackground)
-            .clipShape(RoundedRectangle(cornerRadius: 5, style: .continuous))
-            .overlay(RoundedRectangle(cornerRadius: 5, style: .continuous)
+            .clipShape(customLabelShape ?? CustomLabelShape(RoundedRectangle(cornerRadius: 5, style: .continuous)))
+            .overlay((customLabelShape ?? CustomLabelShape(RoundedRectangle(cornerRadius: 5, style: .continuous)))
                         .stroke(lineColour)
             )
     }
     
-    public func poiAbscissaLabelCenter(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> some View {
+    public func poiAbscissaLabelCenter(
+     marker: String,
+     labelFont: Font,
+     labelColour: Color,
+     labelBackground: Color,
+     lineColour: Color,
+     strokeStyle: StrokeStyle,
+     customLabelShape: CustomLabelShape?,
+     customTextToShapePadding: CGFloat?
+    ) -> some View {
         Text(LocalizedStringKey(marker))
             .font(labelFont)
             .foregroundColor(labelColour)
-            .padding()
+            .padding(.all, customTextToShapePadding)
             .background(labelBackground)
-            .clipShape(DiamondShape())
-            .overlay(DiamondShape()
+            .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+            .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
                         .stroke(lineColour, style: strokeStyle)
             )
     }
     
-    public func poiAbscissaLabelOppositeAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> some View {
+    public func poiAbscissaLabelOppositeAxis(
+     marker: String,
+     labelFont: Font,
+     labelColour: Color,
+     labelBackground: Color,
+     lineColour: Color,
+     strokeStyle: StrokeStyle,
+     customLabelShape: CustomLabelShape?,
+     customTextToShapePadding: CGFloat?
+    ) -> some View {
         VStack {
             if self.chartStyle.xAxisLabelPosition == .top {
                 Spacer()
@@ -498,10 +541,10 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol {
             Text(LocalizedStringKey(marker))
                 .font(labelFont)
                 .foregroundColor(labelColour)
-                .padding()
+                .padding(.all, customTextToShapePadding)
                 .background(labelBackground)
-                .clipShape(DiamondShape())
-                .overlay(DiamondShape()
+                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
                             .stroke(lineColour, style: strokeStyle)
                 )
             if self.chartStyle.xAxisLabelPosition == .bottom {
@@ -517,28 +560,45 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
         HorizontalAbscissaMarker(chartData: self, markerValue: markerValue, dataPointCount: dataPointCount)
     }
     
-    public func poiAbscissaLabelAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color) -> some View {
+    public func poiAbscissaLabelAxis(
+     marker: String,
+     labelFont: Font,
+     labelColour: Color,
+     labelBackground: Color,
+     lineColour: Color,
+     customLabelShape: CustomLabelShape?,
+     customTextToShapePadding: CGFloat?
+    ) -> some View {
         Text(LocalizedStringKey(marker))
             .font(labelFont)
             .foregroundColor(labelColour)
-            .padding(4)
+            .padding(customTextToShapePadding ?? 4)
             .background(labelBackground)
             .ifElse(self.chartStyle.yAxisLabelPosition == .leading, if: {
                 $0
-                    .clipShape(LeadingLabelShape())
-                    .overlay(LeadingLabelShape()
+                    .clipShape(customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(LeadingLabelShape()))
                                 .stroke(lineColour)
                     )
             }, else: {
                 $0
-                    .clipShape(TrailingLabelShape())
-                    .overlay(TrailingLabelShape()
+                    .clipShape(customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
+                    .overlay((customLabelShape ?? CustomLabelShape(TrailingLabelShape()))
                                 .stroke(lineColour)
                     )
             })
     }
     
-    public func poiAbscissaLabelOppositeAxis(marker: String, labelFont: Font, labelColour: Color, labelBackground: Color, lineColour: Color, strokeStyle: StrokeStyle) -> some View {
+    public func poiAbscissaLabelOppositeAxis(
+     marker: String,
+     labelFont: Font,
+     labelColour: Color,
+     labelBackground: Color,
+     lineColour: Color,
+     strokeStyle: StrokeStyle,
+     customLabelShape: CustomLabelShape?,
+     customTextToShapePadding: CGFloat?
+    ) -> some View {
         HStack {
             if self.chartStyle.yAxisLabelPosition == .leading {
                 Spacer()
@@ -546,10 +606,10 @@ extension CTLineBarChartDataProtocol where Self: PointOfInterestProtocol & isHor
             Text(LocalizedStringKey(marker))
                 .font(labelFont)
                 .foregroundColor(labelColour)
-                .padding()
+                .padding(.all, customTextToShapePadding)
                 .background(labelBackground)
-                .clipShape(DiamondShape())
-                .overlay(DiamondShape()
+                .clipShape(customLabelShape ?? CustomLabelShape(DiamondShape()))
+                .overlay((customLabelShape ?? CustomLabelShape(DiamondShape()))
                             .stroke(lineColour, style: strokeStyle)
                 )
             if self.chartStyle.yAxisLabelPosition == .trailing {

--- a/Sources/SwiftUICharts/SharedLineAndBar/Shapes/LabelShape.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/Shapes/LabelShape.swift
@@ -1,6 +1,6 @@
 //
 //  LabelShape.swift
-//  
+//
 //
 //  Created by Will Dale on 08/02/2021.
 //
@@ -8,6 +8,25 @@
 import SwiftUI
 
 // MARK: - Ordinate
+
+/**
+ Custom Label Shape used in POI Markers when displaying POI values.
+ */
+public struct CustomLabelShape: Shape {
+    public init<S: Shape>(_ wrapped: S) {
+        _path = { rect in
+            let path = wrapped.path(in: rect)
+            return path
+        }
+    }
+    
+    public func path(in rect: CGRect) -> Path {
+        return _path(rect)
+    }
+    
+    private let _path: (CGRect) -> Path
+}
+
 /**
  Shape used in POI Markers when displaying value in the Y axis labels on the leading edge.
  */

--- a/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/XAxisPOI.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/XAxisPOI.swift
@@ -27,6 +27,9 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
     private let labelColour: Color
     private let labelBackground: Color
     
+    private let customLabelShape: CustomLabelShape?
+    private let customTextToShapePadding: CGFloat?
+    
     private let addToLegends: Bool
     
     internal init(
@@ -42,6 +45,9 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         labelColour: Color,
         labelBackground: Color,
         
+        customLabelShape: CustomLabelShape?,
+        customTextToShapePadding: CGFloat?,
+        
         addToLegends: Bool
     ) {
         self.chartData = chartData
@@ -56,6 +62,9 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         self.labelFont = labelFont
         self.labelColour = labelColour
         self.labelBackground = labelBackground
+        
+        self.customLabelShape = customLabelShape
+        self.customTextToShapePadding = customTextToShapePadding
         
         self.addToLegends = addToLegends
         
@@ -82,7 +91,9 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                        labelFont: labelFont,
                                                        labelColour: labelColour,
                                                        labelBackground: labelBackground,
-                                                       lineColour: lineColour)
+                                                       lineColour: lineColour,
+                                                       customLabelShape: customLabelShape,
+                                                       customTextToShapePadding: customTextToShapePadding)
                             .position(chartData.poiAbscissaValueLabelPositionAxis(frame: geo.frame(in: .local),
                                                                                   markerValue: markerValue,
                                                                                   count: dataPointCount))
@@ -96,7 +107,9 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                          labelColour: labelColour,
                                                          labelBackground: labelBackground,
                                                          lineColour: lineColour,
-                                                         strokeStyle: strokeStyle)
+                                                         strokeStyle: strokeStyle,
+                                                         customLabelShape: customLabelShape,
+                                                         customTextToShapePadding: customTextToShapePadding)
                             .position(chartData.poiAbscissaValueLabelPositionCenter(frame: geo.frame(in: .local),
                                                                                     markerValue: markerValue,
                                                                                     count: dataPointCount))
@@ -110,7 +123,9 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                        labelColour: labelColour,
                                                        labelBackground: labelBackground,
                                                        lineColour: lineColour,
-                                                       strokeStyle: strokeStyle)
+                                                       strokeStyle: strokeStyle,
+                                                       customLabelShape: customLabelShape,
+                                                       customTextToShapePadding: customTextToShapePadding)
                             .frame(width: geo.frame(in: .local).width, height: geo.frame(in: .local).height)
                             .fixedSize()
                             .position(chartData.poiAbscissaValueLabelPositionOppositeAxis(frame: geo.frame(in: .local),
@@ -182,6 +197,8 @@ extension View {
         - labelBackground: Colour of the background.
         - lineColour: Line Colour.
         - strokeStyle: Style of Stroke.
+        - customLabelShape: Custom Shape for POI Label.
+        - customTextToShapePadding: Custom Padding between Shape and `Text`.
         - addToLegends: Whether or not to add this to the legends.
      - Returns: A  new view containing the chart with a marker line at a specified value.
      */
@@ -196,6 +213,8 @@ extension View {
         labelFont: Font = .caption,
         labelColour: Color = Color.primary,
         labelBackground: Color = Color.systemsBackground,
+        customLabelShape: CustomLabelShape? = nil,
+        customTextToShapePadding: CGFloat? = nil,
         addToLegends: Bool = true
     ) -> some View {
         self.modifier(XAxisPOI(chartData: chartData,
@@ -208,6 +227,8 @@ extension View {
                                labelFont: labelFont,
                                labelColour: labelColour,
                                labelBackground: labelBackground,
+                               customLabelShape: customLabelShape,
+                               customTextToShapePadding: customTextToShapePadding,
                                addToLegends: addToLegends))
     }
 }

--- a/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/XAxisPOI.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/XAxisPOI.swift
@@ -142,7 +142,7 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                     self.startAnimation = false
                 }
             } else { content }
-        }
+        }.zIndex(1)
     }
     
     private func setupPOILegends() {

--- a/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/XAxisPOI.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/XAxisPOI.swift
@@ -29,8 +29,7 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
     private let labelBorderColor: Color
     
     private let customLabelShape: CustomLabelShape?
-    private let customTextToShapePadding: CGFloat?
-    private let labelIcon: AnyView?
+    private let padding: CGFloat?
     
     private let addToLegends: Bool
     
@@ -49,8 +48,7 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         labelBackground: Color,
         
         customLabelShape: CustomLabelShape?,
-        customTextToShapePadding: CGFloat?,
-        labelIcon: AnyView?,
+        padding: CGFloat?,
         
         addToLegends: Bool
     ) {
@@ -69,8 +67,7 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         self.labelBorderColor = labelBorderColor ?? lineColour
         
         self.customLabelShape = customLabelShape
-        self.customTextToShapePadding = customTextToShapePadding
-        self.labelIcon = labelIcon
+        self.padding = padding
         
         self.addToLegends = addToLegends
         
@@ -99,8 +96,7 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                        labelBackground: labelBackground,
                                                        labelBorderColor: labelBorderColor,
                                                        customLabelShape: customLabelShape,
-                                                       customTextToShapePadding: customTextToShapePadding,
-                                                       labelIcon: labelIcon)
+                                                       padding: padding)
                             .position(chartData.poiAbscissaValueLabelPositionAxis(frame: geo.frame(in: .local),
                                                                                   markerValue: markerValue,
                                                                                   count: dataPointCount))
@@ -116,28 +112,27 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                          labelBorderColor: labelBorderColor,
                                                          strokeStyle: strokeStyle,
                                                          customLabelShape: customLabelShape,
-                                                         customTextToShapePadding: customTextToShapePadding,
-                                                         labelIcon: labelIcon)
+                                                         padding: padding)
                             .position(chartData.poiAbscissaValueLabelPositionCenter(frame: geo.frame(in: .local),
                                                                                     markerValue: markerValue,
                                                                                     count: dataPointCount))
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(self.markerName) %@", comment: ""), "\(markerValue)")))
 
-                    case .oppositeYAxis:
+                    case .position(location: let location, _, _):
                         
-                        chartData.poiAbscissaLabelOppositeAxis(marker: markerName,
-                                                               labelFont: labelFont,
-                                                               labelColour: labelColour,
-                                                               labelBackground: labelBackground,
-                                                               labelBorderColor: labelBorderColor,
-                                                               strokeStyle: strokeStyle,
-                                                               customLabelShape: customLabelShape,
-                                                               customTextToShapePadding: customTextToShapePadding,
-                                                               labelIcon: labelIcon)
+                        chartData.poiAbscissaLabelPosition(location: location,
+                                                           marker: markerName,
+                                                           labelFont: labelFont,
+                                                           labelColour: labelColour,
+                                                           labelBackground: labelBackground,
+                                                           labelBorderColor: labelBorderColor,
+                                                           strokeStyle: strokeStyle,
+                                                           customLabelShape: customLabelShape,
+                                                           padding: padding)
                             .frame(width: geo.frame(in: .local).width, height: geo.frame(in: .local).height)
                             .fixedSize()
-                            .position(chartData.poiAbscissaValueLabelPositionOppositeAxis(frame: geo.frame(in: .local),
+                            .position(chartData.poiAbscissaValueLabelRelativePosition(frame: geo.frame(in: .local),
                                                                                     markerValue: markerValue,
                                                                                     count: dataPointCount))
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
@@ -208,8 +203,7 @@ extension View {
         - labelBorderColor: Custom Color for the label border, if not provided lineColor will be used.
         - strokeStyle: Style of Stroke.
         - customLabelShape: Custom Shape for POI Label.
-        - customTextToShapePadding: Custom Padding between Shape and `Text`.
-        - labelIcon: Custom icon to be added with `Text`.
+        - padding: Custom Padding between Shape and `Text`.
         - addToLegends: Whether or not to add this to the legends.
      - Returns: A  new view containing the chart with a marker line at a specified value.
      */
@@ -226,8 +220,7 @@ extension View {
         labelColour: Color = Color.primary,
         labelBackground: Color = Color.systemsBackground,
         customLabelShape: CustomLabelShape? = nil,
-        customTextToShapePadding: CGFloat? = nil,
-        labelIcon: AnyView? = nil,
+        padding: CGFloat? = nil,
         addToLegends: Bool = true
     ) -> some View {
         self.modifier(XAxisPOI(chartData: chartData,
@@ -242,8 +235,7 @@ extension View {
                                labelColour: labelColour,
                                labelBackground: labelBackground,
                                customLabelShape: customLabelShape,
-                               customTextToShapePadding: customTextToShapePadding,
-                               labelIcon: labelIcon,
+                               padding: padding,
                                addToLegends: addToLegends))
     }
 }

--- a/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/XAxisPOI.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/XAxisPOI.swift
@@ -26,9 +26,11 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
     private let labelFont: Font
     private let labelColour: Color
     private let labelBackground: Color
+    private let labelBorderColor: Color
     
     private let customLabelShape: CustomLabelShape?
     private let customTextToShapePadding: CGFloat?
+    private let labelIcon: AnyView?
     
     private let addToLegends: Bool
     
@@ -38,6 +40,7 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         markerValue: Int,
         dataPointCount: Int,
         lineColour: Color,
+        labelBorderColor: Color?,
         strokeStyle: StrokeStyle,
         
         labelPosition: DisplayValue,
@@ -47,6 +50,7 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         
         customLabelShape: CustomLabelShape?,
         customTextToShapePadding: CGFloat?,
+        labelIcon: AnyView?,
         
         addToLegends: Bool
     ) {
@@ -62,9 +66,11 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         self.labelFont = labelFont
         self.labelColour = labelColour
         self.labelBackground = labelBackground
+        self.labelBorderColor = labelBorderColor ?? lineColour
         
         self.customLabelShape = customLabelShape
         self.customTextToShapePadding = customTextToShapePadding
+        self.labelIcon = labelIcon
         
         self.addToLegends = addToLegends
         
@@ -91,9 +97,10 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                        labelFont: labelFont,
                                                        labelColour: labelColour,
                                                        labelBackground: labelBackground,
-                                                       lineColour: lineColour,
+                                                       labelBorderColor: labelBorderColor,
                                                        customLabelShape: customLabelShape,
-                                                       customTextToShapePadding: customTextToShapePadding)
+                                                       customTextToShapePadding: customTextToShapePadding,
+                                                       labelIcon: labelIcon)
                             .position(chartData.poiAbscissaValueLabelPositionAxis(frame: geo.frame(in: .local),
                                                                                   markerValue: markerValue,
                                                                                   count: dataPointCount))
@@ -106,10 +113,11 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                          labelFont: labelFont,
                                                          labelColour: labelColour,
                                                          labelBackground: labelBackground,
-                                                         lineColour: lineColour,
+                                                         labelBorderColor: labelBorderColor,
                                                          strokeStyle: strokeStyle,
                                                          customLabelShape: customLabelShape,
-                                                         customTextToShapePadding: customTextToShapePadding)
+                                                         customTextToShapePadding: customTextToShapePadding,
+                                                         labelIcon: labelIcon)
                             .position(chartData.poiAbscissaValueLabelPositionCenter(frame: geo.frame(in: .local),
                                                                                     markerValue: markerValue,
                                                                                     count: dataPointCount))
@@ -119,13 +127,14 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                     case .oppositeYAxis:
                         
                         chartData.poiAbscissaLabelOppositeAxis(marker: markerName,
-                                                       labelFont: labelFont,
-                                                       labelColour: labelColour,
-                                                       labelBackground: labelBackground,
-                                                       lineColour: lineColour,
-                                                       strokeStyle: strokeStyle,
-                                                       customLabelShape: customLabelShape,
-                                                       customTextToShapePadding: customTextToShapePadding)
+                                                               labelFont: labelFont,
+                                                               labelColour: labelColour,
+                                                               labelBackground: labelBackground,
+                                                               labelBorderColor: labelBorderColor,
+                                                               strokeStyle: strokeStyle,
+                                                               customLabelShape: customLabelShape,
+                                                               customTextToShapePadding: customTextToShapePadding,
+                                                               labelIcon: labelIcon)
                             .frame(width: geo.frame(in: .local).width, height: geo.frame(in: .local).height)
                             .fixedSize()
                             .position(chartData.poiAbscissaValueLabelPositionOppositeAxis(frame: geo.frame(in: .local),
@@ -142,7 +151,7 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                     self.startAnimation = false
                 }
             } else { content }
-        }.zIndex(1)
+        }
     }
     
     private func setupPOILegends() {
@@ -196,9 +205,11 @@ extension View {
         - labelColour: Colour of the `Text`.
         - labelBackground: Colour of the background.
         - lineColour: Line Colour.
+        - labelBorderColor: Custom Color for the label border, if not provided lineColor will be used.
         - strokeStyle: Style of Stroke.
         - customLabelShape: Custom Shape for POI Label.
         - customTextToShapePadding: Custom Padding between Shape and `Text`.
+        - labelIcon: Custom icon to be added with `Text`.
         - addToLegends: Whether or not to add this to the legends.
      - Returns: A  new view containing the chart with a marker line at a specified value.
      */
@@ -208,6 +219,7 @@ extension View {
         markerValue: Int,
         dataPointCount: Int,
         lineColour: Color = Color(.blue),
+        labelBorderColor: Color? = nil,
         strokeStyle: StrokeStyle = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round, miterLimit: 10, dash: [CGFloat](), dashPhase: 0),
         labelPosition: DisplayValue = .center(specifier: "%.0f"),
         labelFont: Font = .caption,
@@ -215,6 +227,7 @@ extension View {
         labelBackground: Color = Color.systemsBackground,
         customLabelShape: CustomLabelShape? = nil,
         customTextToShapePadding: CGFloat? = nil,
+        labelIcon: AnyView? = nil,
         addToLegends: Bool = true
     ) -> some View {
         self.modifier(XAxisPOI(chartData: chartData,
@@ -222,6 +235,7 @@ extension View {
                                markerValue: markerValue,
                                dataPointCount: dataPointCount,
                                lineColour: lineColour,
+                               labelBorderColor: labelBorderColor,
                                strokeStyle: strokeStyle,
                                labelPosition: labelPosition,
                                labelFont: labelFont,
@@ -229,6 +243,7 @@ extension View {
                                labelBackground: labelBackground,
                                customLabelShape: customLabelShape,
                                customTextToShapePadding: customTextToShapePadding,
+                               labelIcon: labelIcon,
                                addToLegends: addToLegends))
     }
 }

--- a/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/XAxisPOI.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/XAxisPOI.swift
@@ -1,6 +1,6 @@
 //
 //  XAxisPOI.swift
-//  
+//
 //
 //  Created by Will Dale on 19/06/2021.
 //
@@ -100,11 +100,24 @@ internal struct XAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                             .position(chartData.poiAbscissaValueLabelPositionCenter(frame: geo.frame(in: .local),
                                                                                     markerValue: markerValue,
                                                                                     count: dataPointCount))
-                            
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(self.markerName) %@", comment: ""), "\(markerValue)")))
 
-//                            .accessibilityValue(LocalizedStringKey("\(markerName), \(markerValue)"))
+                    case .oppositeYAxis:
+                        
+                        chartData.poiAbscissaLabelOppositeAxis(marker: markerName,
+                                                       labelFont: labelFont,
+                                                       labelColour: labelColour,
+                                                       labelBackground: labelBackground,
+                                                       lineColour: lineColour,
+                                                       strokeStyle: strokeStyle)
+                            .frame(width: geo.frame(in: .local).width, height: geo.frame(in: .local).height)
+                            .fixedSize()
+                            .position(chartData.poiAbscissaValueLabelPositionOppositeAxis(frame: geo.frame(in: .local),
+                                                                                    markerValue: markerValue,
+                                                                                    count: dataPointCount))
+                            .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
+                            .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(self.markerName) %@", comment: ""), "\(markerValue)")))
                     }
                 }
                 .animateOnAppear(using: chartData.chartStyle.globalAnimation) {

--- a/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/YAxisPOI.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/YAxisPOI.swift
@@ -145,7 +145,7 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                     self.startAnimation = false
                 }
             } else { content }
-        }
+        }.zIndex(1)
     }
     
     private func setupPOILegends() {

--- a/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/YAxisPOI.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/YAxisPOI.swift
@@ -28,8 +28,7 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
     private let labelBorderColor: Color
     
     private let customLabelShape: CustomLabelShape?
-    private let customTextToShapePadding: CGFloat?
-    private let labelIcon: AnyView?
+    private let padding: CGFloat?
     
     private let addToLegends: Bool
     
@@ -49,8 +48,7 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         labelBorderColor: Color?,
         strokeStyle: StrokeStyle,
         customLabelShape: CustomLabelShape?,
-        customTextToShapePadding: CGFloat?,
-        labelIcon: AnyView?,
+        padding: CGFloat?,
         addToLegends: Bool,
         isAverage: Bool
     ) {
@@ -66,8 +64,7 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         self.labelBorderColor = labelBorderColor ?? lineColour
         
         self.customLabelShape = customLabelShape
-        self.customTextToShapePadding = customTextToShapePadding
-        self.labelIcon = labelIcon
+        self.padding = padding
         
         self.addToLegends = addToLegends
         
@@ -105,8 +102,7 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                labelBackground: labelBackground,
                                                labelBorderColor: labelBorderColor,
                                                customLabelShape: customLabelShape,
-                                               customTextToShapePadding: customTextToShapePadding,
-                                               labelIcon: labelIcon)
+                                               padding: padding)
                             .position(chartData.poiValueLabelPositionAxis(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(markerName) %@", comment: ""), String(format: specifier, markerValue))))
@@ -122,27 +118,26 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                  labelBorderColor: labelBorderColor,
                                                  strokeStyle: strokeStyle,
                                                  customLabelShape: customLabelShape,
-                                                 customTextToShapePadding: customTextToShapePadding,
-                                                 labelIcon: labelIcon)
+                                                 padding: padding)
                             .position(chartData.poiValueLabelPositionCenter(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(markerName) %@", comment: ""), String(format: specifier, markerValue))))
-                    case .oppositeYAxis(specifier: let specifier, formatter: let formatter):
+                    case .position(location: let location, specifier: let specifier, formatter: let formatter):
                         
-                        chartData.poiLabelOppositeAxis(markerValue: markerValue,
-                                                       specifier: specifier,
-                                                       formatter: formatter,
-                                                       labelFont: labelFont,
-                                                       labelColour: labelColour,
-                                                       labelBackground: labelBackground,
-                                                       labelBorderColor: labelBorderColor,
-                                                       strokeStyle: strokeStyle,
-                                                       customLabelShape: customLabelShape,
-                                                       customTextToShapePadding: customTextToShapePadding,
-                                                       labelIcon: labelIcon)
+                        chartData.poiLabelPosition(location: location,
+                                                   markerValue: markerValue,
+                                                   specifier: specifier,
+                                                   formatter: formatter,
+                                                   labelFont: labelFont,
+                                                   labelColour: labelColour,
+                                                   labelBackground: labelBackground,
+                                                   labelBorderColor: labelBorderColor,
+                                                   strokeStyle: strokeStyle,
+                                                   customLabelShape: customLabelShape,
+                                                   padding: padding)
                             .frame(width: geo.frame(in: .local).width, height: geo.frame(in: .local).height)
                             .fixedSize()
-                            .position(chartData.poiValueLabelPositionOppositeYAxis(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
+                            .position(chartData.poiValueLabelRelativePosition(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(markerName) %@", comment: ""), String(format: specifier, markerValue))))
                     }
@@ -154,7 +149,7 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                     self.startAnimation = false
                 }
             } else { content }
-        }.zIndex(1)
+        }
     }
     
     private func setupPOILegends() {
@@ -226,8 +221,7 @@ extension View {
         - labelBorderColor: Custom Color for the label border, if not provided `lineColor` will be used.
         - strokeStyle: Style of Stroke.
         - customLabelShape: Custom Shape for POI Label.
-        - customTextToShapePadding: Custom Padding between Shape and `Text`.
-        - labelIcon: Custom icon to be added with `Text`.
+        - padding: Custom Padding between Shape and `Text`.
         - addToLegends: Whether or not to add this to the legends.
      - Returns: A  new view containing the chart with a marker line at a specified value.
      */
@@ -243,8 +237,7 @@ extension View {
         labelBorderColor: Color? = nil,
         strokeStyle: StrokeStyle = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round, miterLimit: 10, dash: [CGFloat](), dashPhase: 0),
         customLabelShape: CustomLabelShape? = nil,
-        customTextToShapePadding: CGFloat? = nil,
-        labelIcon: AnyView? = nil,
+        padding: CGFloat? = nil,
         addToLegends: Bool = true
     ) -> some View {
         self.modifier(YAxisPOI(chartData: chartData,
@@ -258,8 +251,7 @@ extension View {
                                labelBorderColor: labelBorderColor,
                                strokeStyle: strokeStyle,
                                customLabelShape: customLabelShape,
-                               customTextToShapePadding: customTextToShapePadding,
-                               labelIcon: labelIcon,
+                               padding: padding,
                                addToLegends: addToLegends,
                                isAverage: false))
     }
@@ -319,8 +311,7 @@ extension View {
         - labelBorderColor: Custom Color for the label border, if not provided lineColor will be used.
         - strokeStyle: Style of Stroke.
         - customLabelShape: Custom Shape for POI Label.
-        - customTextToShapePadding: Custom Padding between Shape and `Text`.
-        - labelIcon: Custom icon to be added with `Text`.
+        - padding: Custom Padding between Shape and `Text`.
         - addToLegends: Whether or not to add this to the legends.
      - Returns: A  new view containing the chart with a marker line at the average.
      */
@@ -335,8 +326,7 @@ extension View {
         labelBorderColor: Color? = nil,
         strokeStyle: StrokeStyle = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round, miterLimit: 10, dash: [CGFloat](), dashPhase: 0),
         customLabelShape: CustomLabelShape? = nil,
-        customTextToShapePadding: CGFloat? = nil,
-        labelIcon: AnyView? = nil,
+        padding: CGFloat? = nil,
         addToLegends: Bool = true
     ) -> some View {
         self.modifier(YAxisPOI(chartData: chartData,
@@ -349,8 +339,7 @@ extension View {
                                labelBorderColor: labelBorderColor,
                                strokeStyle: strokeStyle,
                                customLabelShape: customLabelShape,
-                               customTextToShapePadding: customTextToShapePadding,
-                               labelIcon: labelIcon,
+                               padding: padding,
                                addToLegends: addToLegends,
                                isAverage: true))
     }

--- a/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/YAxisPOI.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/YAxisPOI.swift
@@ -26,6 +26,9 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
     private let labelColour: Color
     private let labelBackground: Color
     
+    private let customLabelShape: CustomLabelShape?
+    private let customTextToShapePadding: CGFloat?
+    
     private let addToLegends: Bool
     
     private let range: Double
@@ -42,6 +45,8 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         labelBackground: Color,
         lineColour: Color,
         strokeStyle: StrokeStyle,
+        customLabelShape: CustomLabelShape?,
+        customTextToShapePadding: CGFloat?,
         addToLegends: Bool,
         isAverage: Bool
     ) {
@@ -54,6 +59,9 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         self.labelFont = labelFont
         self.labelColour = labelColour
         self.labelBackground = labelBackground
+        
+        self.customLabelShape = customLabelShape
+        self.customTextToShapePadding = customTextToShapePadding
         
         self.addToLegends = addToLegends
         
@@ -89,7 +97,9 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                labelFont: labelFont,
                                                labelColour: labelColour,
                                                labelBackground: labelBackground,
-                                               lineColour: lineColour)
+                                               lineColour: lineColour,
+                                               customLabelShape: customLabelShape,
+                                               customTextToShapePadding: customTextToShapePadding)
                             .position(chartData.poiValueLabelPositionAxis(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(markerName) %@", comment: ""), String(format: specifier, markerValue))))
@@ -103,7 +113,9 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                  labelColour: labelColour,
                                                  labelBackground: labelBackground,
                                                  lineColour: lineColour,
-                                                 strokeStyle: strokeStyle)
+                                                 strokeStyle: strokeStyle,
+                                                 customLabelShape: customLabelShape,
+                                                 customTextToShapePadding: customTextToShapePadding)
                             .position(chartData.poiValueLabelPositionCenter(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(markerName) %@", comment: ""), String(format: specifier, markerValue))))
@@ -116,7 +128,9 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                        labelColour: labelColour,
                                                        labelBackground: labelBackground,
                                                        lineColour: lineColour,
-                                                       strokeStyle: strokeStyle)
+                                                       strokeStyle: strokeStyle,
+                                                       customLabelShape: customLabelShape,
+                                                       customTextToShapePadding: customTextToShapePadding)
                             .frame(width: geo.frame(in: .local).width, height: geo.frame(in: .local).height)
                             .fixedSize()
                             .position(chartData.poiValueLabelPositionOppositeYAxis(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
@@ -201,6 +215,8 @@ extension View {
         - labelBackground: Colour of the background.
         - lineColour: Line Colour.
         - strokeStyle: Style of Stroke.
+        - customLabelShape: Custom Shape for POI Label.
+        - customTextToShapePadding: Custom Padding between Shape and `Text`.
         - addToLegends: Whether or not to add this to the legends.
      - Returns: A  new view containing the chart with a marker line at a specified value.
      */
@@ -214,6 +230,8 @@ extension View {
         labelBackground: Color = Color.systemsBackground,
         lineColour: Color = Color(.blue),
         strokeStyle: StrokeStyle = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round, miterLimit: 10, dash: [CGFloat](), dashPhase: 0),
+        customLabelShape: CustomLabelShape? = nil,
+        customTextToShapePadding: CGFloat? = nil,
         addToLegends: Bool = true
     ) -> some View {
         self.modifier(YAxisPOI(chartData: chartData,
@@ -225,6 +243,8 @@ extension View {
                                labelBackground: labelBackground,
                                lineColour: lineColour,
                                strokeStyle: strokeStyle,
+                               customLabelShape: customLabelShape,
+                               customTextToShapePadding: customTextToShapePadding,
                                addToLegends: addToLegends,
                                isAverage: false))
     }
@@ -282,6 +302,8 @@ extension View {
         - labelBackground: Colour of the background.
         - lineColour: Line Colour.
         - strokeStyle: Style of Stroke.
+        - customLabelShape: Custom Shape for POI Label.
+        - customTextToShapePadding: Custom Padding between Shape and `Text`.
         - addToLegends: Whether or not to add this to the legends.
      - Returns: A  new view containing the chart with a marker line at the average.
      */
@@ -294,6 +316,8 @@ extension View {
         labelBackground: Color = Color.systemsBackground,
         lineColour: Color = Color.primary,
         strokeStyle: StrokeStyle = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round, miterLimit: 10, dash: [CGFloat](), dashPhase: 0),
+        customLabelShape: CustomLabelShape? = nil,
+        customTextToShapePadding: CGFloat? = nil,
         addToLegends: Bool = true
     ) -> some View {
         self.modifier(YAxisPOI(chartData: chartData,
@@ -304,6 +328,8 @@ extension View {
                                labelBackground: labelBackground,
                                lineColour: lineColour,
                                strokeStyle: strokeStyle,
+                               customLabelShape: customLabelShape,
+                               customTextToShapePadding: customTextToShapePadding,
                                addToLegends: addToLegends,
                                isAverage: true))
     }

--- a/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/YAxisPOI.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/YAxisPOI.swift
@@ -25,9 +25,11 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
     private let labelFont: Font
     private let labelColour: Color
     private let labelBackground: Color
+    private let labelBorderColor: Color
     
     private let customLabelShape: CustomLabelShape?
     private let customTextToShapePadding: CGFloat?
+    private let labelIcon: AnyView?
     
     private let addToLegends: Bool
     
@@ -44,9 +46,11 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         labelColour: Color,
         labelBackground: Color,
         lineColour: Color,
+        labelBorderColor: Color?,
         strokeStyle: StrokeStyle,
         customLabelShape: CustomLabelShape?,
         customTextToShapePadding: CGFloat?,
+        labelIcon: AnyView?,
         addToLegends: Bool,
         isAverage: Bool
     ) {
@@ -59,9 +63,11 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
         self.labelFont = labelFont
         self.labelColour = labelColour
         self.labelBackground = labelBackground
+        self.labelBorderColor = labelBorderColor ?? lineColour
         
         self.customLabelShape = customLabelShape
         self.customTextToShapePadding = customTextToShapePadding
+        self.labelIcon = labelIcon
         
         self.addToLegends = addToLegends
         
@@ -97,9 +103,10 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                labelFont: labelFont,
                                                labelColour: labelColour,
                                                labelBackground: labelBackground,
-                                               lineColour: lineColour,
+                                               labelBorderColor: labelBorderColor,
                                                customLabelShape: customLabelShape,
-                                               customTextToShapePadding: customTextToShapePadding)
+                                               customTextToShapePadding: customTextToShapePadding,
+                                               labelIcon: labelIcon)
                             .position(chartData.poiValueLabelPositionAxis(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(markerName) %@", comment: ""), String(format: specifier, markerValue))))
@@ -112,10 +119,11 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                  labelFont: labelFont,
                                                  labelColour: labelColour,
                                                  labelBackground: labelBackground,
-                                                 lineColour: lineColour,
+                                                 labelBorderColor: labelBorderColor,
                                                  strokeStyle: strokeStyle,
                                                  customLabelShape: customLabelShape,
-                                                 customTextToShapePadding: customTextToShapePadding)
+                                                 customTextToShapePadding: customTextToShapePadding,
+                                                 labelIcon: labelIcon)
                             .position(chartData.poiValueLabelPositionCenter(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(markerName) %@", comment: ""), String(format: specifier, markerValue))))
@@ -127,10 +135,11 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                        labelFont: labelFont,
                                                        labelColour: labelColour,
                                                        labelBackground: labelBackground,
-                                                       lineColour: lineColour,
+                                                       labelBorderColor: labelBorderColor,
                                                        strokeStyle: strokeStyle,
                                                        customLabelShape: customLabelShape,
-                                                       customTextToShapePadding: customTextToShapePadding)
+                                                       customTextToShapePadding: customTextToShapePadding,
+                                                       labelIcon: labelIcon)
                             .frame(width: geo.frame(in: .local).width, height: geo.frame(in: .local).height)
                             .fixedSize()
                             .position(chartData.poiValueLabelPositionOppositeYAxis(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
@@ -214,9 +223,11 @@ extension View {
         - labelColour: Colour of the `Text`.
         - labelBackground: Colour of the background.
         - lineColour: Line Colour.
+        - labelBorderColor: Custom Color for the label border, if not provided `lineColor` will be used.
         - strokeStyle: Style of Stroke.
         - customLabelShape: Custom Shape for POI Label.
         - customTextToShapePadding: Custom Padding between Shape and `Text`.
+        - labelIcon: Custom icon to be added with `Text`.
         - addToLegends: Whether or not to add this to the legends.
      - Returns: A  new view containing the chart with a marker line at a specified value.
      */
@@ -229,9 +240,11 @@ extension View {
         labelColour: Color = Color.primary,
         labelBackground: Color = Color.systemsBackground,
         lineColour: Color = Color(.blue),
+        labelBorderColor: Color? = nil,
         strokeStyle: StrokeStyle = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round, miterLimit: 10, dash: [CGFloat](), dashPhase: 0),
         customLabelShape: CustomLabelShape? = nil,
         customTextToShapePadding: CGFloat? = nil,
+        labelIcon: AnyView? = nil,
         addToLegends: Bool = true
     ) -> some View {
         self.modifier(YAxisPOI(chartData: chartData,
@@ -242,9 +255,11 @@ extension View {
                                labelColour: labelColour,
                                labelBackground: labelBackground,
                                lineColour: lineColour,
+                               labelBorderColor: labelBorderColor,
                                strokeStyle: strokeStyle,
                                customLabelShape: customLabelShape,
                                customTextToShapePadding: customTextToShapePadding,
+                               labelIcon: labelIcon,
                                addToLegends: addToLegends,
                                isAverage: false))
     }
@@ -301,9 +316,11 @@ extension View {
         - labelColour: Colour of the `Text`.
         - labelBackground: Colour of the background.
         - lineColour: Line Colour.
+        - labelBorderColor: Custom Color for the label border, if not provided lineColor will be used.
         - strokeStyle: Style of Stroke.
         - customLabelShape: Custom Shape for POI Label.
         - customTextToShapePadding: Custom Padding between Shape and `Text`.
+        - labelIcon: Custom icon to be added with `Text`.
         - addToLegends: Whether or not to add this to the legends.
      - Returns: A  new view containing the chart with a marker line at the average.
      */
@@ -315,9 +332,11 @@ extension View {
         labelColour: Color = Color.primary,
         labelBackground: Color = Color.systemsBackground,
         lineColour: Color = Color.primary,
+        labelBorderColor: Color? = nil,
         strokeStyle: StrokeStyle = StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round, miterLimit: 10, dash: [CGFloat](), dashPhase: 0),
         customLabelShape: CustomLabelShape? = nil,
         customTextToShapePadding: CGFloat? = nil,
+        labelIcon: AnyView? = nil,
         addToLegends: Bool = true
     ) -> some View {
         self.modifier(YAxisPOI(chartData: chartData,
@@ -327,9 +346,11 @@ extension View {
                                labelColour: labelColour,
                                labelBackground: labelBackground,
                                lineColour: lineColour,
+                               labelBorderColor: labelBorderColor,
                                strokeStyle: strokeStyle,
                                customLabelShape: customLabelShape,
                                customTextToShapePadding: customTextToShapePadding,
+                               labelIcon: labelIcon,
                                addToLegends: addToLegends,
                                isAverage: true))
     }

--- a/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/YAxisPOI.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/ViewModifiers/YAxisPOI.swift
@@ -91,7 +91,6 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                labelBackground: labelBackground,
                                                lineColour: lineColour)
                             .position(chartData.poiValueLabelPositionAxis(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
-                            
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(markerName) %@", comment: ""), String(format: specifier, markerValue))))
                         
@@ -106,7 +105,21 @@ internal struct YAxisPOI<T>: ViewModifier where T: CTLineBarChartDataProtocol & 
                                                  lineColour: lineColour,
                                                  strokeStyle: strokeStyle)
                             .position(chartData.poiValueLabelPositionCenter(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
-                            
+                            .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
+                            .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(markerName) %@", comment: ""), String(format: specifier, markerValue))))
+                    case .oppositeYAxis(specifier: let specifier, formatter: let formatter):
+                        
+                        chartData.poiLabelOppositeAxis(markerValue: markerValue,
+                                                       specifier: specifier,
+                                                       formatter: formatter,
+                                                       labelFont: labelFont,
+                                                       labelColour: labelColour,
+                                                       labelBackground: labelBackground,
+                                                       lineColour: lineColour,
+                                                       strokeStyle: strokeStyle)
+                            .frame(width: geo.frame(in: .local).width, height: geo.frame(in: .local).height)
+                            .fixedSize()
+                            .position(chartData.poiValueLabelPositionOppositeYAxis(frame: geo.frame(in: .local), markerValue: markerValue, minValue: minValue, range: range))
                             .accessibilityLabel(LocalizedStringKey("P-O-I-Marker"))
                             .accessibilityValue(LocalizedStringKey(String(format: NSLocalizedString("\(markerName) %@", comment: ""), String(format: specifier, markerValue))))
                     }

--- a/Sources/SwiftUICharts/SharedLineAndBar/Views/PositionedPOILabel.swift
+++ b/Sources/SwiftUICharts/SharedLineAndBar/Views/PositionedPOILabel.swift
@@ -1,0 +1,95 @@
+//
+//  PositionedPOILabel.swift
+//  SwiftUICharts
+//
+//  Created by Kunal Verma on 16/01/22.
+//
+
+import SwiftUI
+
+internal struct PositionedPOILabel<Content>: View where Content: View {
+    
+    enum Orientation {
+        case horizontal
+        case vertical
+    }
+    
+    let content: () -> Content
+    let orientation: Orientation
+    let distanceFromLeading: CGFloat
+    @State var contentSize: CGFloat = 0
+    @State var containerSize: CGFloat = 0
+    
+    init(@ViewBuilder content: @escaping () -> Content, orientation: Orientation, distanceFromLeading: CGFloat) {
+        self.content = content
+        self.orientation = orientation
+        self.distanceFromLeading = distanceFromLeading
+    }
+    
+    var body: some View {
+        if orientation == .horizontal {
+            horizontalView()
+        } else {
+            verticalView()
+        }
+    }
+    
+    @ViewBuilder
+    func horizontalView() -> some View {
+        HStack(spacing: 0) {
+            Spacer()
+                .frame(width: (containerSize - contentSize) * distanceFromLeading)
+            content()
+                .background(
+                    GeometryReader { geo in
+                        Rectangle()
+                            .foregroundColor(Color.clear)
+                            .onAppear {
+                                self.contentSize = geo.size.width
+                            }
+                    }
+                )
+                .fixedSize()
+            Spacer()
+        }
+        .background(
+            GeometryReader { stackGeo in
+                Rectangle()
+                    .foregroundColor(Color.clear)
+                    .onAppear {
+                        self.containerSize = stackGeo.size.width
+                    }
+            }
+        )
+    }
+    
+    @ViewBuilder
+    func verticalView() -> some View {
+        VStack(spacing: 0) {
+            Spacer()
+                .frame(height: (containerSize - contentSize) * distanceFromLeading)
+            content()
+                .background(
+                    GeometryReader { geo in
+                        Rectangle()
+                            .foregroundColor(Color.clear)
+                            .onAppear {
+                                self.contentSize = geo.size.height
+                            }
+                    }
+                )
+                .fixedSize()
+            Spacer()
+        }
+        .background(
+            GeometryReader { stackGeo in
+                Rectangle()
+                    .foregroundColor(Color.clear)
+                    .onAppear {
+                        self.containerSize = stackGeo.size.height
+                    }
+            }
+        )
+        
+    }
+}


### PR DESCRIPTION
Addition of .oppositeYAxis DisplayValue Enum for showing POI labels at the opposite end of yAxis
Enhancement for #160 and #162 

Enhancements/Fixes -
- Addition of configurable label and poi options
- Position inside chart for label
- Custom Border Color for the label
- Custom Shape and Padding for the Label