### PR TITLE
fix: HorizontalBarChart xAxisLabelPosition = .bottom.

### DIFF
--- a/Sources/SwiftUICharts/BarChart/Models/ChartData/HorizontalBarChartData.swift
+++ b/Sources/SwiftUICharts/BarChart/Models/ChartData/HorizontalBarChartData.swift
@@ -120,6 +120,10 @@ public final class HorizontalBarChartData: CTHorizontalBarChartDataProtocol, Get
                         Spacer()
                             .frame(minHeight: 0, maxHeight: 500)
                     }
+                    if self.chartStyle.xAxisLabelPosition == .bottom {
+                        Spacer()
+                            .frame(height: yAxisPaddingHeight + 8) // Why 8 ?
+                    }
                 }
                 
             case .chartData:


### PR DESCRIPTION
It seems that this branch is deleted accidentally in some reorganizing attempts.