### PR TITLE
Update How VoiceOver Announces Grouped Bar Charts

### DIFF
--- a/Sources/SwiftUICharts/BarChart/Views/GroupedBarChart.swift
+++ b/Sources/SwiftUICharts/BarChart/Views/GroupedBarChart.swift
@@ -70,6 +70,8 @@ public struct GroupedBarChart<ChartData>: View where ChartData: GroupedBarChartD
                 .onAppear {
                     self.chartData.viewData.chartSize = geo.frame(in: .local)
                 }
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel(LocalizedStringKey(chartData.metadata.title))
                 .layoutNotifier(timer)
             } else { CustomNoDataView(chartData: chartData) }
         }
@@ -123,7 +125,7 @@ internal struct GroupedBarCell<ChartData>: View where ChartData: GroupedBarChart
                 ColourBar(chartData: chartData,
                           dataPoint: dataPoint,
                           colour: colour)
-                    .accessibilityLabel(LocalizedStringKey(chartData.metadata.title))
+                    .accessibilityLabel(LocalizedStringKey(dataPoint.group.title))
             } else if dataPoint.group.colour.colourType == .gradientColour,
                       let colours = dataPoint.group.colour.colours,
                       let startPoint = dataPoint.group.colour.startPoint,
@@ -134,7 +136,7 @@ internal struct GroupedBarCell<ChartData>: View where ChartData: GroupedBarChart
                                    colours: colours,
                                    startPoint: startPoint,
                                    endPoint: endPoint)
-                    .accessibilityLabel(LocalizedStringKey(chartData.metadata.title))
+                    .accessibilityLabel(LocalizedStringKey(dataPoint.group.title))
             } else if dataPoint.group.colour.colourType == .gradientStops,
                       let stops = dataPoint.group.colour.stops,
                       let startPoint = dataPoint.group.colour.startPoint,
@@ -146,7 +148,7 @@ internal struct GroupedBarCell<ChartData>: View where ChartData: GroupedBarChart
                                  stops: safeStops,
                                  startPoint: startPoint,
                                  endPoint: endPoint)
-                    .accessibilityLabel(LocalizedStringKey(chartData.metadata.title))
+                    .accessibilityLabel(LocalizedStringKey(dataPoint.group.title))
             }
         }
     }


### PR DESCRIPTION
Using the contain option for the .accessibilityElement(children: ) modifier. with an accessibility label. That way, the first time that the focus moves to one of the elements in the chart, the title of the chart will be announced preceding the accessibility label and value for the bar. Update the bars so it announces the title for the group of the data point instead of the title of the chart every time.

This way, it seems to be a bit less redundant and it provides instead important information, to what legend item corresponds each one of the bars.

Before:

https://user-images.githubusercontent.com/2143610/188285605-f8741f77-77e8-49b0-ad39-76da27dec4fa.MP4

After:

https://user-images.githubusercontent.com/2143610/188285665-944635b8-27b2-4691-b6d6-6614a37e9df1.MP4


