### PR TITLE
Fix ProjectionTransform Warning in Pie Charts

### DIFF
--- a/Sources/SwiftUICharts/PieChart/Views/PieChart.swift
+++ b/Sources/SwiftUICharts/PieChart/Views/PieChart.swift
@@ -79,7 +79,7 @@ public struct PieChart<ChartData>: View where ChartData: PieChartData {
         if chartData.disableAnimation {
             return 1
         } else {
-            return startAnimation ? 1 : 0
+            return startAnimation ? 1 : 0.001
         }
     }
 }


### PR DESCRIPTION
Don’t scale all the way to zero to avoid the warning below.
> ignoring singular matrix: ProjectionTransform(m11: 5e-324, m12: 0.0, m13: 0.0, m21: 0.0, m22: 5e-324, m23: 0.0, m31: 191.0, m32: 203.75, m33: 1.0)

Warning Detail: https://github.com/willdale/SwiftUICharts/issues/79