### PR TITLE
Show legend circle only when legend title is not empty

### DIFF
--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
@@ -129,7 +129,7 @@ extension CTChartData {
     @ViewBuilder public func infoLegend(info: DataPoint) -> some View {
         if let legend = self.legends.first(where: {
             $0.legend == info.legendTag
-        }) {
+        }), !legend.legend.isEmpty {
             legend.getLegendAsCircle(textColor: .primary)
         } else {
             EmptyView()


### PR DESCRIPTION
I have added a check to show the legend title and circle of if there is some text for legend title.
Otherwise it was just showing a circle with an empty string