### PR TITLE
Xcode 16 type-check error 

### DIFF
--- a/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
+++ b/Sources/SwiftUICharts/Shared/Models/Protocols/SharedProtocolsExtensions.swift
@@ -221,11 +221,11 @@ extension CTMultiDataSetProtocol where Self.DataSet.DataPoint: CTStandardDataPoi
     public func average() -> Double {
         
         self.dataSets
-            .compactMap {
-                $0.dataPoints
+            .compactMap { dataSet -> Double in
+                dataSet.dataPoints
                     .map(\.value)
                     .reduce(0, +)
-                    .divide(by: Double($0.dataPoints.count))
+                    .divide(by: Double(dataSet.dataPoints.count))
             }
             .reduce(0, +)
             .divide(by: Double(self.dataSets.count))


### PR DESCRIPTION
## Summary
* Declare the type for the compactMap to reduce complexity on the compiler while type-checking to fix error while trying to compile from Xcode 16. 

## Screenshot of Issue
![SwiftUIChartsTypeCheckIssue](https://github.com/user-attachments/assets/7e922a84-a3c7-4f68-a09a-a25c77a20aea)
